### PR TITLE
fix: correct syntax in gatsby-config.js for consistency

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,4 @@
-const { siteConfig } = require('./src/config/site.ts')
+const { siteConfig } = require('./src/config/site.ts');
 
 /**
  * @type {import('gatsby').GatsbyConfig}
@@ -56,4 +56,4 @@ module.exports = {
       },
     },
   ],
-}
+};


### PR DESCRIPTION
- Added a semicolon at the end of the import statement for siteConfig.
- Ensured proper formatting of the module exports to maintain code style consistency.