### PR TITLE
feat: add github projects page with card layout

### DIFF
--- a/.github/plans/projects.md
+++ b/.github/plans/projects.md
@@ -1,0 +1,437 @@
+# Projects Page PRD & Developer Brief
+
+## Overview
+
+Add a `/projects` page to alexnodeland.github.io that showcases technical work as a curated catalog with modal detail views. The page should reflect the compositional philosophy that underlies the work: complex wholes emerging from simple, well-governed parts.
+
+-----
+
+## Goals
+
+1. **Showcase technical depth** — Feature foundational libraries and infrastructure that demonstrate engineering sophistication, not just applications
+1. **Enable discovery** — Allow visitors to filter/browse by category and status without overwhelming navigation
+1. **Keep it self-contained** — Project details render in modals rather than separate pages; external links point to GitHub, docs, or existing blog posts
+1. **Signal builder identity** — Distinguish between active/maintained work and archived experiments
+1. **Complement the blog** — Projects page serves as quick reference; blog posts provide deeper narrative. Both coexist and link between them where relevant
+
+-----
+
+## Information Architecture
+
+```
+/projects
+├── Intro Section
+│   └── Brief compositional philosophy (2-3 sentences)
+├── Featured Section
+│   └── Prominent cards for foundational work
+└── Catalog Section
+    ├── Filter controls (category, status)
+    └── Project grid
+```
+
+### Categories
+
+|Category        |Description                                 |Examples                                                |
+|----------------|--------------------------------------------|--------------------------------------------------------|
+|`library`       |Reusable primitives and core abstractions   |Fugue, Fugue-evo, Quiver                                |
+|`infrastructure`|Frameworks, templates, dev tooling          |Principled, Artifactr                                   |
+|`application`   |Production apps, deployed and maintained    |TBD                                                     |
+|`experiment`    |Weekend projects, learning exercises, closed|Finance Crew, Crewlit, Resume Crew, Vanilla ReAct, QCSim|
+|`tool`          |Personal utilities                          |RSS reader, Obsidian plugin                             |
+|`fork`          |Maintained forks of external projects       |TBD                                                     |
+|`research`      |Academic/research work                      |Wavelet bases for audio compression                     |
+
+### Status
+
+|Status    |Description                                    |
+|----------|-----------------------------------------------|
+|`active`  |Actively developed/maintained                  |
+|`stable`  |Complete, maintained but not actively developed|
+|`archived`|Closed, historical interest only               |
+
+### Featured Flag
+
+Projects marked `featured: true` appear in the Featured Section with enhanced visual treatment. Current featured projects:
+
+- Fugue
+- Fugue-evo
+- Quiver
+- Principled
+- Artifactr
+
+-----
+
+## Project Data Model
+
+Each project is a configuration object:
+
+```typescript
+interface Project {
+  // Identity
+  id: string;                    // URL-safe slug
+  name: string;                  // Display name
+  tagline: string;               // One-line description (< 100 chars)
+  
+  // Classification
+  category: 'library' | 'infrastructure' | 'application' | 'experiment' | 'tool' | 'fork' | 'research';
+  status: 'active' | 'stable' | 'archived';
+  featured: boolean;
+  
+  // Content
+  description: string;           // Markdown, renders in modal (200-500 words)
+  highlights?: string[];         // Optional bullet points for key features/achievements
+  
+  // Links
+  links: ProjectLink[];
+  
+  // Metadata
+  tags: string[];                // For filtering/search: languages, domains, techniques
+  year?: number;                 // Year started or published
+  
+  // Fork-specific (optional)
+  upstream?: {
+    name: string;
+    url: string;
+  };
+  forkReason?: string;           // Brief note on modifications/why maintained
+  
+  // GitHub metadata (fetched at build time or client-side)
+  github?: {
+    repo: string;                // "owner/repo" format for API calls
+    stars?: number;              // Cached star count
+    lastCommit?: string;         // ISO date of last commit
+  };
+}
+
+interface ProjectLink {
+  type: 'github' | 'docs' | 'blog' | 'demo' | 'paper' | 'npm' | 'crates';
+  url: string;
+  label?: string;                // Override default label
+}
+```
+
+-----
+
+## UI Components
+
+### Page Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Nav (existing)                                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  # projects                                                 │
+│                                                             │
+│  i build systems where elegant abstractions compose into   │
+│  complex behavior through well-governed local rules.        │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ## featured                                                │
+│                                                             │
+│  ┌───────────────┐ ┌───────────────┐ ┌───────────────┐     │
+│  │   Fugue       │ │  Fugue-evo    │ │    Quiver     │     │
+│  │   [tagline]   │ │   [tagline]   │ │   [tagline]   │     │
+│  │   [tags]      │ │   [tags]      │ │   [tags]      │     │
+│  └───────────────┘ └───────────────┘ └───────────────┘     │
+│                                                             │
+│  ┌───────────────┐ ┌───────────────┐                       │
+│  │  Principled   │ │   Artifactr   │                       │
+│  │   [tagline]   │ │   [tagline]   │                       │
+│  │   [tags]      │ │   [tags]      │                       │
+│  └───────────────┘ └───────────────┘                       │
+│                                                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ## catalog                                                 │
+│                                                             │
+│  [all ▾] [category ▾] [status ▾]        [search...]        │
+│                                                             │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           │
+│  │ Project │ │ Project │ │ Project │ │ Project │           │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘           │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           │
+│  │ Project │ │ Project │ │ Project │ │ Project │           │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘           │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Project Card
+
+```
+┌───────────────────────────────────┐
+│  [category badge]       [status]  │
+│                                   │
+│  Project Name                     │
+│  Tagline text here...             │
+│                                   │
+│  [tag] [tag] [tag]                │
+│                                   │
+│  ★ 42  •  Updated 3 days ago      │
+│                                   │
+│  [GitHub] [Docs]                  │
+└───────────────────────────────────┘
+```
+
+**GitHub stats**: Show star count and relative last commit date (e.g., “3 days ago”, “2 months ago”). Omit for projects without GitHub repos.
+
+**Featured cards** are larger (2x width or taller) with more prominent treatment.
+
+**Fork cards** show upstream attribution: “Fork of [upstream] — [forkReason]”
+
+### Project Modal
+
+Triggered on card click. Contains:
+
+- Header: name, tagline, category badge, status
+- Description (rendered markdown)
+- Highlights (if present)
+- Links (prominent buttons)
+- Tags
+- For forks: upstream info and modification notes
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                              [×]            │
+│  [library] [active]                                         │
+│                                                             │
+│  Fugue                                                      │
+│  Monadic probabilistic programming for Rust                 │
+│                                                             │
+│  ─────────────────────────────────────────────────────────  │
+│                                                             │
+│  [Description markdown rendered here. Can include code      │
+│  blocks, links, etc. 200-500 words covering what it is,     │
+│  why it exists, key technical decisions, current state.]    │
+│                                                             │
+│  **Highlights**                                             │
+│  • Defunctionalized CPS monad implementation                │
+│  • Type-safe probabilistic programming                      │
+│  • MCMC, SMC, Variational Inference, ABC                    │
+│                                                             │
+│  ─────────────────────────────────────────────────────────  │
+│                                                             │
+│  [rust] [probabilistic-programming] [monads] [sampling]     │
+│                                                             │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐                    │
+│  │  GitHub  │ │   Docs   │ │   Blog   │                    │
+│  └──────────┘ └──────────┘ └──────────┘                    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+-----
+
+## Filtering & Search
+
+### Filter Controls
+
+- **Category dropdown**: All, Library, Infrastructure, Application, Experiment, Tool, Fork, Research
+- **Status dropdown**: All, Active, Stable, Archived
+- **Text search**: Filters by name, tagline, tags (client-side)
+
+Filters combine with AND logic. URL params update to enable sharing filtered views:
+`/projects?category=library&status=active`
+
+### Default View
+
+- Featured section always visible (unaffected by filters)
+- Catalog defaults to showing all projects, sorted by: featured first, then active before archived, then alphabetically
+
+-----
+
+## Visual Design
+
+### Consistency with Existing Site
+
+- Match existing nav, typography, color scheme
+- Use same card/section patterns as homepage “how i can help” grid
+- Add “projects” to main nav alongside “blog” and “cv”
+
+### Category Badges
+
+Subtle colored badges to distinguish categories at a glance:
+
+|Category      |Color suggestion|
+|--------------|----------------|
+|library       |blue            |
+|infrastructure|purple          |
+|application   |green           |
+|experiment    |orange          |
+|tool          |gray            |
+|fork          |teal            |
+|research      |indigo          |
+
+### Status Indicators
+
+- `active`: green dot or “active” text
+- `stable`: neutral/no indicator (default state)
+- `archived`: muted styling, perhaps lower opacity
+
+-----
+
+## Data Management
+
+### Where Projects Live
+
+Projects defined in a single data file (JSON, YAML, or TypeScript const) that gets imported at build time:
+
+```
+/src/data/projects.ts  (or .json / .yaml)
+```
+
+This keeps project data separate from presentation logic and makes it easy to add/update projects without touching components.
+
+### Example Project Entry
+
+```typescript
+{
+  id: "fugue",
+  name: "Fugue",
+  tagline: "Monadic probabilistic programming for Rust",
+  category: "library",
+  status: "active",
+  featured: true,
+  description: `
+Fugue is a production-ready, monadic probabilistic programming library for Rust...
+
+## Architecture
+
+The library uses a defunctionalized CPS monad implementation that enables...
+
+## Inference Methods
+
+- MCMC (Metropolis-Hastings, HMC)
+- SMC (Sequential Monte Carlo)
+- Variational Inference
+- Approximate Bayesian Computation (ABC)
+  `,
+  highlights: [
+    "Defunctionalized CPS monad implementation",
+    "Type-safe probabilistic programming",
+    "Multiple inference backends"
+  ],
+  links: [
+    { type: "github", url: "https://github.com/alexnodeland/fugue" },
+    { type: "blog", url: "/alexnodeland/blog/250819_fugue/" },
+    { type: "crates", url: "https://crates.io/crates/fugue" }
+  ],
+  tags: ["rust", "probabilistic-programming", "monads", "mcmc", "bayesian"],
+  year: 2025
+}
+```
+
+-----
+
+## Implementation Notes
+
+### Tech Stack
+
+Match existing site setup (appears to be Gatsby or similar static site generator with React). Key implementation points:
+
+1. **Page component**: `/src/pages/projects.tsx` (or `.js`)
+1. **Data file**: `/src/data/projects.ts`
+1. **Components**:
+- `ProjectCard` — renders individual project in grid
+- `ProjectModal` — detail view overlay
+- `ProjectFilters` — filter controls
+- `FeaturedSection` — featured projects layout
+- `CatalogSection` — filterable grid
+
+### GitHub Data Fetching
+
+For star count and last commit date, two options:
+
+**Option A: Build-time fetch (recommended)**
+
+- Use GitHub API during build to fetch stats for each project with a `github.repo` field
+- Cache results in the build output
+- Pros: No client-side API calls, no rate limiting concerns, fast page load
+- Cons: Data only as fresh as last build (fine for personal site)
+
+```javascript
+// In gatsby-node.js or similar build script
+const fetchGitHubStats = async (repo) => {
+  const [repoData, commits] = await Promise.all([
+    fetch(`https://api.github.com/repos/${repo}`),
+    fetch(`https://api.github.com/repos/${repo}/commits?per_page=1`)
+  ]);
+  return {
+    stars: repoData.stargazers_count,
+    lastCommit: commits[0]?.commit?.committer?.date
+  };
+};
+```
+
+**Option B: Client-side fetch**
+
+- Fetch on page load or lazily
+- Pros: Always fresh
+- Cons: Rate limiting (60 req/hr unauthenticated), slower initial render
+
+Recommend Option A with a daily/weekly rebuild trigger if you want freshness.
+
+### Accessibility
+
+- Modal should trap focus, close on Escape
+- Cards should be keyboard navigable
+- Filter controls should be properly labeled
+- Images (if any) need alt text
+
+### SEO
+
+- Page title: “projects | alex nodeland”
+- Meta description: “Technical projects and open source work by Alex Nodeland — probabilistic programming, agent frameworks, audio synthesis, and development infrastructure.”
+- Consider structured data for software projects (schema.org/SoftwareSourceCode)
+
+### Performance
+
+- Lazy load modal content if descriptions are large
+- Consider virtualization if project count grows significantly (probably not needed initially)
+
+-----
+
+## Project Inventory (To Be Filled)
+
+|Project                 |Category      |Status  |Featured|Links               |
+|------------------------|--------------|--------|--------|--------------------|
+|Fugue                   |library       |active  |✓       |github, blog, crates|
+|Fugue-evo               |library       |active  |✓       |github              |
+|Quiver                  |library       |active  |✓       |github              |
+|Principled              |infrastructure|active  |✓       |github              |
+|Artifactr               |infrastructure|active  |✓       |github              |
+|Finance Crew            |experiment    |archived|        |github, blog        |
+|Crewlit                 |experiment    |archived|        |github, blog        |
+|Resume Crew             |experiment    |archived|        |github, blog        |
+|Vanilla ReAct           |experiment    |archived|        |github, blog        |
+|QCSim                   |experiment    |archived|        |github, blog        |
+|Algorithm Visualizations|experiment    |stable  |        |blog                |
+|RSS Reader              |tool          |?       |        |github              |
+|Obsidian Plugin         |tool          |?       |        |github              |
+|Wavelet Research        |research      |archived|        |blog                |
+|[Forks TBD]             |fork          |?       |        |github              |
+
+-----
+
+## Success Criteria
+
+1. Visitor can quickly understand the scope and nature of your technical work
+1. Featured projects demonstrate genuine technical depth (not just “I used React”)
+1. Clear distinction between foundational work and experiments
+1. Easy to navigate, filter, and find specific projects
+1. Modal detail views provide enough context without requiring external clicks
+1. Page loads fast, works on mobile
+1. Consistent with existing site aesthetic
+
+-----
+
+## Next Steps
+
+1. [ ] Fill in project inventory with accurate statuses and links
+1. [ ] Write descriptions for featured projects (Fugue, Fugue-evo, Quiver, Principled, Artifactr)
+1. [ ] Build components
+1. [ ] Populate data file
+1. [ ] Add to navigation
+1. [ ] Test and iterate

--- a/src/__tests__/unit/components/projects/ProjectCard.test.tsx
+++ b/src/__tests__/unit/components/projects/ProjectCard.test.tsx
@@ -101,7 +101,7 @@ describe('ProjectCard Component', () => {
   it('should call onClick when card is clicked', () => {
     render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
 
-    const card = screen.getByRole('button');
+    const card = screen.getByTestId('project-card');
     fireEvent.click(card);
 
     expect(mockOnClick).toHaveBeenCalledTimes(1);
@@ -116,14 +116,14 @@ describe('ProjectCard Component', () => {
       />
     );
 
-    const card = screen.getByRole('button');
+    const card = screen.getByTestId('project-card');
     expect(card).toHaveClass('featured');
   });
 
   it('should apply archived class for archived projects', () => {
     render(<ProjectCard project={mockArchivedProject} onClick={mockOnClick} />);
 
-    const card = screen.getByRole('button');
+    const card = screen.getByTestId('project-card');
     expect(card).toHaveClass('archived');
   });
 
@@ -139,7 +139,7 @@ describe('ProjectCard Component', () => {
   it('should be keyboard accessible', () => {
     render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
 
-    const card = screen.getByRole('button');
+    const card = screen.getByTestId('project-card');
 
     // Test Enter key
     fireEvent.keyDown(card, { key: 'Enter' });

--- a/src/__tests__/unit/components/projects/ProjectCard.test.tsx
+++ b/src/__tests__/unit/components/projects/ProjectCard.test.tsx
@@ -1,0 +1,210 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ProjectCard from '../../../../components/projects/ProjectCard';
+import type { Project } from '../../../../config/projects';
+
+// Mock project data
+const mockProject: Project = {
+  id: 'test-project',
+  name: 'Test Project',
+  tagline: 'a test project for unit testing',
+  category: 'library',
+  status: 'active',
+  featured: false,
+  description: 'This is a test project description.',
+  highlights: ['Feature 1', 'Feature 2'],
+  links: [
+    { type: 'github', url: 'https://github.com/test/test' },
+    { type: 'docs', url: 'https://docs.test.com' },
+  ],
+  tags: ['typescript', 'react', 'testing'],
+  year: 2024,
+  github: {
+    repo: 'test/test',
+    stars: 42,
+    lastCommit: new Date().toISOString(),
+  },
+};
+
+const mockFeaturedProject: Project = {
+  ...mockProject,
+  id: 'featured-project',
+  name: 'Featured Project',
+  featured: true,
+};
+
+const mockArchivedProject: Project = {
+  ...mockProject,
+  id: 'archived-project',
+  name: 'Archived Project',
+  status: 'archived',
+};
+
+const mockForkProject: Project = {
+  ...mockProject,
+  id: 'fork-project',
+  name: 'Fork Project',
+  category: 'fork',
+  upstream: {
+    name: 'Original Project',
+    url: 'https://github.com/original/project',
+  },
+  forkReason: 'Added custom features',
+};
+
+describe('ProjectCard Component', () => {
+  const mockOnClick = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render project card with basic information', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    expect(screen.getByText('Test Project')).toBeInTheDocument();
+    expect(
+      screen.getByText('a test project for unit testing')
+    ).toBeInTheDocument();
+    expect(screen.getByText('library')).toBeInTheDocument();
+  });
+
+  it('should render status indicator for active projects', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('should render project tags', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    expect(screen.getByText('typescript')).toBeInTheDocument();
+    expect(screen.getByText('react')).toBeInTheDocument();
+    expect(screen.getByText('testing')).toBeInTheDocument();
+  });
+
+  it('should render GitHub stats when available', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('should render link buttons', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    const githubButton = screen.getByTitle('GitHub');
+    const docsButton = screen.getByTitle('Docs');
+
+    expect(githubButton).toBeInTheDocument();
+    expect(docsButton).toBeInTheDocument();
+  });
+
+  it('should call onClick when card is clicked', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    const card = screen.getByRole('button');
+    fireEvent.click(card);
+
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should apply featured class when featured prop is true', () => {
+    render(
+      <ProjectCard
+        project={mockFeaturedProject}
+        onClick={mockOnClick}
+        featured
+      />
+    );
+
+    const card = screen.getByRole('button');
+    expect(card).toHaveClass('featured');
+  });
+
+  it('should apply archived class for archived projects', () => {
+    render(<ProjectCard project={mockArchivedProject} onClick={mockOnClick} />);
+
+    const card = screen.getByRole('button');
+    expect(card).toHaveClass('archived');
+  });
+
+  it('should render fork information for fork projects', () => {
+    render(<ProjectCard project={mockForkProject} onClick={mockOnClick} />);
+
+    expect(screen.getByText('fork')).toBeInTheDocument();
+    expect(screen.getByText(/fork of/i)).toBeInTheDocument();
+    expect(screen.getByText('Original Project')).toBeInTheDocument();
+    expect(screen.getByText(/Added custom features/)).toBeInTheDocument();
+  });
+
+  it('should be keyboard accessible', () => {
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    const card = screen.getByRole('button');
+
+    // Test Enter key
+    fireEvent.keyDown(card, { key: 'Enter' });
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+
+    // Test Space key
+    fireEvent.keyDown(card, { key: ' ' });
+    expect(mockOnClick).toHaveBeenCalledTimes(2);
+  });
+
+  it('should stop propagation when link button is clicked', () => {
+    const windowOpen = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<ProjectCard project={mockProject} onClick={mockOnClick} />);
+
+    const githubButton = screen.getByTitle('GitHub');
+    fireEvent.click(githubButton);
+
+    // onClick should not be called when clicking the link button
+    expect(mockOnClick).not.toHaveBeenCalled();
+    expect(windowOpen).toHaveBeenCalledWith(
+      'https://github.com/test/test',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    windowOpen.mockRestore();
+  });
+
+  it('should limit displayed tags to 4', () => {
+    const projectWithManyTags: Project = {
+      ...mockProject,
+      tags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5', 'tag6'],
+    };
+
+    render(<ProjectCard project={projectWithManyTags} onClick={mockOnClick} />);
+
+    expect(screen.getByText('tag1')).toBeInTheDocument();
+    expect(screen.getByText('tag2')).toBeInTheDocument();
+    expect(screen.getByText('tag3')).toBeInTheDocument();
+    expect(screen.getByText('tag4')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(screen.queryByText('tag5')).not.toBeInTheDocument();
+  });
+
+  it('should not show status indicator for stable projects', () => {
+    const stableProject: Project = {
+      ...mockProject,
+      status: 'stable',
+    };
+
+    render(<ProjectCard project={stableProject} onClick={mockOnClick} />);
+
+    expect(screen.queryByText('stable')).not.toBeInTheDocument();
+  });
+
+  it('should render correctly without GitHub metadata', () => {
+    const projectWithoutGithub: Project = {
+      ...mockProject,
+      github: undefined,
+    };
+
+    render(<ProjectCard project={projectWithoutGithub} onClick={mockOnClick} />);
+
+    expect(screen.getByText('Test Project')).toBeInTheDocument();
+    expect(screen.queryByText('42')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/unit/components/projects/ProjectFilters.test.tsx
+++ b/src/__tests__/unit/components/projects/ProjectFilters.test.tsx
@@ -1,0 +1,215 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ProjectFilters from '../../../../components/projects/ProjectFilters';
+import type { ProjectCategory, ProjectStatus } from '../../../../config/projects';
+
+describe('ProjectFilters Component', () => {
+  const mockOnCategoryChange = jest.fn();
+  const mockOnStatusChange = jest.fn();
+  const mockOnSearchChange = jest.fn();
+  const mockOnClearFilters = jest.fn();
+
+  const defaultProps = {
+    selectedCategory: null as ProjectCategory | null,
+    selectedStatus: null as ProjectStatus | null,
+    searchTerm: '',
+    onCategoryChange: mockOnCategoryChange,
+    onStatusChange: mockOnStatusChange,
+    onSearchChange: mockOnSearchChange,
+    onClearFilters: mockOnClearFilters,
+    availableCategories: [
+      'library',
+      'infrastructure',
+      'experiment',
+    ] as ProjectCategory[],
+    availableStatuses: ['active', 'stable', 'archived'] as ProjectStatus[],
+    resultCount: 5,
+    totalCount: 10,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render filter controls', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    expect(screen.getByLabelText('category')).toBeInTheDocument();
+    expect(screen.getByLabelText('status')).toBeInTheDocument();
+    expect(screen.getByLabelText('search')).toBeInTheDocument();
+  });
+
+  it('should render category dropdown with all options', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const categorySelect = screen.getByLabelText('category');
+    expect(categorySelect).toBeInTheDocument();
+
+    // Check for option values
+    expect(screen.getByText('all categories')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'library' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'infrastructure' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'experiment' })
+    ).toBeInTheDocument();
+  });
+
+  it('should render status dropdown with all options', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const statusSelect = screen.getByLabelText('status');
+    expect(statusSelect).toBeInTheDocument();
+
+    expect(screen.getByText('all statuses')).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'active' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'stable' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'archived' })).toBeInTheDocument();
+  });
+
+  it('should call onCategoryChange when category is selected', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const categorySelect = screen.getByLabelText('category');
+    fireEvent.change(categorySelect, { target: { value: 'library' } });
+
+    expect(mockOnCategoryChange).toHaveBeenCalledWith('library');
+  });
+
+  it('should call onCategoryChange with null when "all categories" is selected', () => {
+    render(
+      <ProjectFilters {...defaultProps} selectedCategory="library" />
+    );
+
+    const categorySelect = screen.getByLabelText('category');
+    fireEvent.change(categorySelect, { target: { value: '' } });
+
+    expect(mockOnCategoryChange).toHaveBeenCalledWith(null);
+  });
+
+  it('should call onStatusChange when status is selected', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const statusSelect = screen.getByLabelText('status');
+    fireEvent.change(statusSelect, { target: { value: 'active' } });
+
+    expect(mockOnStatusChange).toHaveBeenCalledWith('active');
+  });
+
+  it('should call onStatusChange with null when "all statuses" is selected', () => {
+    render(<ProjectFilters {...defaultProps} selectedStatus="active" />);
+
+    const statusSelect = screen.getByLabelText('status');
+    fireEvent.change(statusSelect, { target: { value: '' } });
+
+    expect(mockOnStatusChange).toHaveBeenCalledWith(null);
+  });
+
+  it('should call onSearchChange when search input changes', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const searchInput = screen.getByPlaceholderText('search projects...');
+    fireEvent.change(searchInput, { target: { value: 'test query' } });
+
+    expect(mockOnSearchChange).toHaveBeenCalledWith('test query');
+  });
+
+  it('should display results count', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    expect(screen.getByText('showing 5 of 10 projects')).toBeInTheDocument();
+  });
+
+  it('should show clear filters button when filters are active', () => {
+    render(
+      <ProjectFilters {...defaultProps} selectedCategory="library" />
+    );
+
+    expect(screen.getByText('clear filters')).toBeInTheDocument();
+  });
+
+  it('should not show clear filters button when no filters are active', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    expect(screen.queryByText('clear filters')).not.toBeInTheDocument();
+  });
+
+  it('should call onClearFilters when clear filters button is clicked', () => {
+    render(
+      <ProjectFilters {...defaultProps} selectedCategory="library" />
+    );
+
+    const clearButton = screen.getByText('clear filters');
+    fireEvent.click(clearButton);
+
+    expect(mockOnClearFilters).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show clear filters when status filter is active', () => {
+    render(<ProjectFilters {...defaultProps} selectedStatus="active" />);
+
+    expect(screen.getByText('clear filters')).toBeInTheDocument();
+  });
+
+  it('should show clear filters when search term is active', () => {
+    render(<ProjectFilters {...defaultProps} searchTerm="test" />);
+
+    expect(screen.getByText('clear filters')).toBeInTheDocument();
+  });
+
+  it('should show clear search button when search term is present', () => {
+    render(<ProjectFilters {...defaultProps} searchTerm="test query" />);
+
+    const clearSearchButton = screen.getByLabelText('Clear search');
+    expect(clearSearchButton).toBeInTheDocument();
+  });
+
+  it('should call onSearchChange with empty string when clear search is clicked', () => {
+    render(<ProjectFilters {...defaultProps} searchTerm="test query" />);
+
+    const clearSearchButton = screen.getByLabelText('Clear search');
+    fireEvent.click(clearSearchButton);
+
+    expect(mockOnSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('should not show clear search button when search term is empty', () => {
+    render(<ProjectFilters {...defaultProps} searchTerm="" />);
+
+    expect(screen.queryByLabelText('Clear search')).not.toBeInTheDocument();
+  });
+
+  it('should have search icon visible', () => {
+    render(<ProjectFilters {...defaultProps} />);
+
+    const searchWrapper = screen
+      .getByPlaceholderText('search projects...')
+      .closest('.search-input-wrapper');
+    expect(searchWrapper?.querySelector('.search-icon')).toBeInTheDocument();
+  });
+
+  it('should display selected category value', () => {
+    render(
+      <ProjectFilters {...defaultProps} selectedCategory="infrastructure" />
+    );
+
+    const categorySelect = screen.getByLabelText('category') as HTMLSelectElement;
+    expect(categorySelect.value).toBe('infrastructure');
+  });
+
+  it('should display selected status value', () => {
+    render(<ProjectFilters {...defaultProps} selectedStatus="archived" />);
+
+    const statusSelect = screen.getByLabelText('status') as HTMLSelectElement;
+    expect(statusSelect.value).toBe('archived');
+  });
+
+  it('should display search term value', () => {
+    render(<ProjectFilters {...defaultProps} searchTerm="fugue" />);
+
+    const searchInput = screen.getByPlaceholderText(
+      'search projects...'
+    ) as HTMLInputElement;
+    expect(searchInput.value).toBe('fugue');
+  });
+});

--- a/src/__tests__/unit/components/projects/ProjectModal.test.tsx
+++ b/src/__tests__/unit/components/projects/ProjectModal.test.tsx
@@ -1,0 +1,268 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ProjectModal from '../../../../components/projects/ProjectModal';
+import type { Project } from '../../../../config/projects';
+
+// Mock project data
+const mockProject: Project = {
+  id: 'test-project',
+  name: 'Test Project',
+  tagline: 'a test project for unit testing',
+  category: 'library',
+  status: 'active',
+  featured: true,
+  description: `
+## Overview
+
+This is a test project description with **markdown**.
+
+## Features
+
+- Feature one
+- Feature two
+  `.trim(),
+  highlights: ['Highlight 1', 'Highlight 2', 'Highlight 3'],
+  links: [
+    { type: 'github', url: 'https://github.com/test/test' },
+    { type: 'docs', url: 'https://docs.test.com' },
+    { type: 'blog', url: '/blog/test-project' },
+  ],
+  tags: ['typescript', 'react', 'testing', 'monads'],
+  year: 2024,
+  github: {
+    repo: 'test/test',
+    stars: 100,
+  },
+};
+
+const mockForkProject: Project = {
+  ...mockProject,
+  id: 'fork-project',
+  name: 'Fork Project',
+  category: 'fork',
+  upstream: {
+    name: 'Original Project',
+    url: 'https://github.com/original/project',
+  },
+  forkReason: 'Custom modifications',
+};
+
+describe('ProjectModal Component', () => {
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset body overflow
+    document.body.style.overflow = '';
+  });
+
+  afterEach(() => {
+    // Clean up body overflow
+    document.body.style.overflow = '';
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(
+      <ProjectModal
+        project={mockProject}
+        isOpen={false}
+        onClose={mockOnClose}
+      />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should not render when project is null', () => {
+    render(
+      <ProjectModal project={null} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should render modal when isOpen is true and project is provided', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Test Project')).toBeInTheDocument();
+  });
+
+  it('should display project header information', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.getByText('Test Project')).toBeInTheDocument();
+    expect(
+      screen.getByText('a test project for unit testing')
+    ).toBeInTheDocument();
+    expect(screen.getByText('library')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getByText('2024')).toBeInTheDocument();
+  });
+
+  it('should render project description', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    // ReactMarkdown is mocked in setupTests.js to just render children
+    expect(screen.getByText(/Overview/)).toBeInTheDocument();
+  });
+
+  it('should render project highlights', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.getByText('highlights')).toBeInTheDocument();
+    expect(screen.getByText('Highlight 1')).toBeInTheDocument();
+    expect(screen.getByText('Highlight 2')).toBeInTheDocument();
+    expect(screen.getByText('Highlight 3')).toBeInTheDocument();
+  });
+
+  it('should render all tags', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.getByText('typescript')).toBeInTheDocument();
+    expect(screen.getByText('react')).toBeInTheDocument();
+    expect(screen.getByText('testing')).toBeInTheDocument();
+    expect(screen.getByText('monads')).toBeInTheDocument();
+  });
+
+  it('should render link buttons', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Documentation')).toBeInTheDocument();
+    expect(screen.getByText('Blog Post')).toBeInTheDocument();
+  });
+
+  it('should call onClose when close button is clicked', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    const closeButton = screen.getByLabelText('Close modal');
+    fireEvent.click(closeButton);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onClose when overlay is clicked', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    const overlay = screen.getByRole('dialog');
+    fireEvent.click(overlay);
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not call onClose when modal content is clicked', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    // Click on the modal title (inside modal content)
+    const title = screen.getByText('Test Project');
+    fireEvent.click(title);
+
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('should call onClose when Escape key is pressed', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should set body overflow to hidden when open', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    expect(document.body.style.overflow).toBe('hidden');
+  });
+
+  it('should render fork information for fork projects', () => {
+    render(
+      <ProjectModal
+        project={mockForkProject}
+        isOpen={true}
+        onClose={mockOnClose}
+      />
+    );
+
+    expect(screen.getByText('fork')).toBeInTheDocument();
+    expect(screen.getByText(/fork of/)).toBeInTheDocument();
+    expect(screen.getByText('Original Project')).toBeInTheDocument();
+    expect(screen.getByText(/Custom modifications/)).toBeInTheDocument();
+  });
+
+  it('should not render highlights section if project has no highlights', () => {
+    const projectWithoutHighlights: Project = {
+      ...mockProject,
+      highlights: undefined,
+    };
+
+    render(
+      <ProjectModal
+        project={projectWithoutHighlights}
+        isOpen={true}
+        onClose={mockOnClose}
+      />
+    );
+
+    expect(screen.queryByText('highlights')).not.toBeInTheDocument();
+  });
+
+  it('should not render year badge if project has no year', () => {
+    const projectWithoutYear: Project = {
+      ...mockProject,
+      year: undefined,
+    };
+
+    render(
+      <ProjectModal
+        project={projectWithoutYear}
+        isOpen={true}
+        onClose={mockOnClose}
+      />
+    );
+
+    expect(screen.queryByText('2024')).not.toBeInTheDocument();
+  });
+
+  it('should have correct aria attributes', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title');
+  });
+
+  it('should render links with correct href', () => {
+    render(
+      <ProjectModal project={mockProject} isOpen={true} onClose={mockOnClose} />
+    );
+
+    const githubLink = screen.getByText('GitHub').closest('a');
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/test/test');
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/__tests__/unit/components/projects/index.test.ts
+++ b/src/__tests__/unit/components/projects/index.test.ts
@@ -1,0 +1,26 @@
+import * as ProjectsExports from '../../../../components/projects';
+
+describe('Projects Components Index', () => {
+  it('should export ProjectCard', () => {
+    expect(ProjectsExports.ProjectCard).toBeDefined();
+    expect(typeof ProjectsExports.ProjectCard).toBe('object');
+  });
+
+  it('should export ProjectModal', () => {
+    expect(ProjectsExports.ProjectModal).toBeDefined();
+    expect(typeof ProjectsExports.ProjectModal).toBe('object');
+  });
+
+  it('should export ProjectFilters', () => {
+    expect(ProjectsExports.ProjectFilters).toBeDefined();
+    expect(typeof ProjectsExports.ProjectFilters).toBe('object');
+  });
+
+  it('should export exactly 3 components', () => {
+    const exportKeys = Object.keys(ProjectsExports);
+    expect(exportKeys).toHaveLength(3);
+    expect(exportKeys).toContain('ProjectCard');
+    expect(exportKeys).toContain('ProjectModal');
+    expect(exportKeys).toContain('ProjectFilters');
+  });
+});

--- a/src/__tests__/unit/components/projects/index.test.ts
+++ b/src/__tests__/unit/components/projects/index.test.ts
@@ -3,17 +3,17 @@ import * as ProjectsExports from '../../../../components/projects';
 describe('Projects Components Index', () => {
   it('should export ProjectCard', () => {
     expect(ProjectsExports.ProjectCard).toBeDefined();
-    expect(typeof ProjectsExports.ProjectCard).toBe('object');
+    expect(typeof ProjectsExports.ProjectCard).toBe('function');
   });
 
   it('should export ProjectModal', () => {
     expect(ProjectsExports.ProjectModal).toBeDefined();
-    expect(typeof ProjectsExports.ProjectModal).toBe('object');
+    expect(typeof ProjectsExports.ProjectModal).toBe('function');
   });
 
   it('should export ProjectFilters', () => {
     expect(ProjectsExports.ProjectFilters).toBeDefined();
-    expect(typeof ProjectsExports.ProjectFilters).toBe('object');
+    expect(typeof ProjectsExports.ProjectFilters).toBe('function');
   });
 
   it('should export exactly 3 components', () => {

--- a/src/__tests__/unit/config/helpers.test.ts
+++ b/src/__tests__/unit/config/helpers.test.ts
@@ -63,6 +63,7 @@ describe('Configuration Helper Functions', () => {
 
       expect(navItems).toEqual([
         { name: 'blog', href: '/blog' },
+        { name: 'projects', href: '/projects' },
         { name: 'cv', href: '/cv' },
       ]);
     });

--- a/src/__tests__/unit/config/projects.test.ts
+++ b/src/__tests__/unit/config/projects.test.ts
@@ -1,0 +1,216 @@
+import {
+  projectsConfig,
+  categoryConfig,
+  statusConfig,
+  getLanguageColor,
+  getProjectCategories,
+  getProjectStatuses,
+} from '../../../config/projects';
+import type {
+  Project,
+  ProjectCategory,
+  ProjectStatus,
+  ProjectLinkType,
+} from '../../../config/projects';
+
+describe('Projects Config', () => {
+  describe('projectsConfig', () => {
+    it('should have a title', () => {
+      expect(projectsConfig.title).toBe('projects');
+    });
+
+    it('should have a subtitle', () => {
+      expect(projectsConfig.subtitle).toBeTruthy();
+      expect(typeof projectsConfig.subtitle).toBe('string');
+    });
+
+    it('should have an array of projects', () => {
+      expect(Array.isArray(projectsConfig.projects)).toBe(true);
+      expect(projectsConfig.projects.length).toBeGreaterThan(0);
+    });
+
+    it('should have featured projects', () => {
+      const featuredProjects = projectsConfig.projects.filter(p => p.featured);
+      expect(featuredProjects.length).toBeGreaterThan(0);
+    });
+
+    describe('project structure', () => {
+      it('each project should have required fields', () => {
+        projectsConfig.projects.forEach((project: Project) => {
+          expect(project.id).toBeTruthy();
+          expect(project.name).toBeTruthy();
+          expect(project.tagline).toBeTruthy();
+          expect(project.category).toBeTruthy();
+          expect(project.status).toBeTruthy();
+          expect(typeof project.featured).toBe('boolean');
+          expect(project.description).toBeTruthy();
+          expect(Array.isArray(project.links)).toBe(true);
+          expect(Array.isArray(project.tags)).toBe(true);
+        });
+      });
+
+      it('each project should have a unique id', () => {
+        const ids = projectsConfig.projects.map(p => p.id);
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).toBe(ids.length);
+      });
+
+      it('each project should have valid category', () => {
+        const validCategories: ProjectCategory[] = [
+          'library',
+          'infrastructure',
+          'application',
+          'experiment',
+          'tool',
+          'fork',
+          'research',
+        ];
+        projectsConfig.projects.forEach(project => {
+          expect(validCategories).toContain(project.category);
+        });
+      });
+
+      it('each project should have valid status', () => {
+        const validStatuses: ProjectStatus[] = ['active', 'stable', 'archived'];
+        projectsConfig.projects.forEach(project => {
+          expect(validStatuses).toContain(project.status);
+        });
+      });
+
+      it('each project link should have valid type and url', () => {
+        const validLinkTypes: ProjectLinkType[] = [
+          'github',
+          'docs',
+          'blog',
+          'demo',
+          'paper',
+          'npm',
+          'crates',
+        ];
+        projectsConfig.projects.forEach(project => {
+          project.links.forEach(link => {
+            expect(validLinkTypes).toContain(link.type);
+            expect(link.url).toBeTruthy();
+          });
+        });
+      });
+
+      it('each project should have at least one tag', () => {
+        projectsConfig.projects.forEach(project => {
+          expect(project.tags.length).toBeGreaterThan(0);
+        });
+      });
+    });
+
+    describe('fork projects', () => {
+      it('fork projects should have upstream info', () => {
+        const forkProjects = projectsConfig.projects.filter(
+          p => p.category === 'fork'
+        );
+        forkProjects.forEach(project => {
+          expect(project.upstream).toBeTruthy();
+          expect(project.upstream?.name).toBeTruthy();
+          expect(project.upstream?.url).toBeTruthy();
+        });
+      });
+    });
+  });
+
+  describe('categoryConfig', () => {
+    it('should have config for all categories', () => {
+      const categories: ProjectCategory[] = [
+        'library',
+        'infrastructure',
+        'application',
+        'experiment',
+        'tool',
+        'fork',
+        'research',
+      ];
+      categories.forEach(category => {
+        expect(categoryConfig[category]).toBeDefined();
+        expect(categoryConfig[category].label).toBeTruthy();
+        expect(categoryConfig[category].color).toMatch(/^#[0-9a-fA-F]{6}$/);
+      });
+    });
+  });
+
+  describe('statusConfig', () => {
+    it('should have config for all statuses', () => {
+      const statuses: ProjectStatus[] = ['active', 'stable', 'archived'];
+      statuses.forEach(status => {
+        expect(statusConfig[status]).toBeDefined();
+        expect(statusConfig[status].label).toBeTruthy();
+        expect(statusConfig[status].color).toMatch(/^#[0-9a-fA-F]{6}$/);
+      });
+    });
+  });
+
+  describe('getLanguageColor', () => {
+    it('should return color for known languages', () => {
+      expect(getLanguageColor('TypeScript')).toBe('#3178c6');
+      expect(getLanguageColor('Python')).toBe('#3572A5');
+      expect(getLanguageColor('Rust')).toBe('#dea584');
+      expect(getLanguageColor('JavaScript')).toBe('#f1e05a');
+    });
+
+    it('should return default color for unknown languages', () => {
+      expect(getLanguageColor('UnknownLanguage')).toBe('#6e7681');
+      expect(getLanguageColor('')).toBe('#6e7681');
+    });
+
+    it('should return valid hex color codes', () => {
+      const hexColorRegex = /^#[0-9a-fA-F]{6}$/;
+      expect(getLanguageColor('TypeScript')).toMatch(hexColorRegex);
+      expect(getLanguageColor('Unknown')).toMatch(hexColorRegex);
+    });
+  });
+
+  describe('getProjectCategories', () => {
+    it('should return an array of categories', () => {
+      const categories = getProjectCategories();
+      expect(Array.isArray(categories)).toBe(true);
+      expect(categories.length).toBeGreaterThan(0);
+    });
+
+    it('should return unique categories from projects', () => {
+      const categories = getProjectCategories();
+      const uniqueCategories = new Set(categories);
+      expect(uniqueCategories.size).toBe(categories.length);
+    });
+
+    it('should only include categories that exist in projects', () => {
+      const categories = getProjectCategories();
+      const projectCategories = new Set(
+        projectsConfig.projects.map(p => p.category)
+      );
+      categories.forEach(category => {
+        expect(projectCategories.has(category)).toBe(true);
+      });
+    });
+  });
+
+  describe('getProjectStatuses', () => {
+    it('should return an array of statuses', () => {
+      const statuses = getProjectStatuses();
+      expect(Array.isArray(statuses)).toBe(true);
+      expect(statuses.length).toBeGreaterThan(0);
+    });
+
+    it('should return unique statuses from projects', () => {
+      const statuses = getProjectStatuses();
+      const uniqueStatuses = new Set(statuses);
+      expect(uniqueStatuses.size).toBe(statuses.length);
+    });
+
+    it('should only include statuses that exist in projects', () => {
+      const statuses = getProjectStatuses();
+      const projectStatuses = new Set(
+        projectsConfig.projects.map(p => p.status)
+      );
+      statuses.forEach(status => {
+        expect(projectStatuses.has(status)).toBe(true);
+      });
+    });
+  });
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,3 +16,6 @@ export { default as SkillsSection } from './cv/CVSkillsSection';
 
 // Chat components
 export * from './chat';
+
+// Projects components
+export * from './projects';

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -77,6 +77,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({
       onClick={onClick}
       role="button"
       tabIndex={0}
+      data-testid="project-card"
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();

--- a/src/components/projects/ProjectCard.tsx
+++ b/src/components/projects/ProjectCard.tsx
@@ -1,0 +1,201 @@
+import React from 'react';
+import type { Project, ProjectLinkType } from '../../config/projects';
+import { categoryConfig, statusConfig } from '../../config/projects';
+
+interface ProjectCardProps {
+  project: Project;
+  onClick: () => void;
+  featured?: boolean;
+}
+
+// Link type icons
+const linkIcons: Record<ProjectLinkType, React.ReactNode> = {
+  github: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
+    </svg>
+  ),
+  docs: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z" />
+    </svg>
+  ),
+  blog: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+  ),
+  demo: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25Zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z" />
+    </svg>
+  ),
+  paper: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75ZM5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574V2.75a2.25 2.25 0 0 0-2.25-2.25Zm3.247 9.572a3.75 3.75 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25l-.005 7.322Z" />
+    </svg>
+  ),
+  npm: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M0 0v16h16V0H0zm13 13H8v-2H5v2H3V3h10v10zm-5-7H5v5h3V6zm5 0h-3v5h1V7h1v4h1V6z" />
+    </svg>
+  ),
+  crates: (
+    <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
+      <path d="M8 0L0 4v8l8 4 8-4V4L8 0zm6.5 4.5L8 8 1.5 4.5 8 1l6.5 3.5zM1 5.5l6.5 3.25V15L1 11.5V5.5zm7.5 9.5V8.75L15 5.5v6l-6.5 3.5z" />
+    </svg>
+  ),
+};
+
+const linkLabels: Record<ProjectLinkType, string> = {
+  github: 'GitHub',
+  docs: 'Docs',
+  blog: 'Blog',
+  demo: 'Demo',
+  paper: 'Paper',
+  npm: 'npm',
+  crates: 'crates.io',
+};
+
+const ProjectCard: React.FC<ProjectCardProps> = ({
+  project,
+  onClick,
+  featured = false,
+}) => {
+  const categoryStyle = categoryConfig[project.category];
+  const statusStyle = statusConfig[project.status];
+  const isArchived = project.status === 'archived';
+
+  const handleLinkClick = (e: React.MouseEvent, url: string) => {
+    e.stopPropagation();
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <article
+      className={`project-card ${featured ? 'featured' : ''} ${isArchived ? 'archived' : ''}`}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+    >
+      <div className="project-card-content">
+        {/* Header with badges */}
+        <div className="project-card-header">
+          <span
+            className="category-badge"
+            style={{ backgroundColor: categoryStyle.color }}
+          >
+            {categoryStyle.label}
+          </span>
+          {project.status !== 'stable' && (
+            <span
+              className="status-indicator"
+              style={{ color: statusStyle.color }}
+            >
+              <span
+                className="status-dot"
+                style={{ backgroundColor: statusStyle.color }}
+              />
+              {statusStyle.label}
+            </span>
+          )}
+        </div>
+
+        {/* Title and tagline */}
+        <h3 className="project-name">{project.name}</h3>
+        <p className="project-tagline">{project.tagline}</p>
+
+        {/* Fork info */}
+        {project.upstream && (
+          <p className="fork-info">
+            fork of{' '}
+            <a
+              href={project.upstream.url}
+              onClick={e => handleLinkClick(e, project.upstream!.url)}
+            >
+              {project.upstream.name}
+            </a>
+            {project.forkReason && <span> — {project.forkReason}</span>}
+          </p>
+        )}
+
+        {/* Tags */}
+        <div className="project-tags">
+          {project.tags.slice(0, 4).map(tag => (
+            <span key={tag} className="project-tag">
+              {tag}
+            </span>
+          ))}
+          {project.tags.length > 4 && (
+            <span className="project-tag more">+{project.tags.length - 4}</span>
+          )}
+        </div>
+
+        {/* Footer with GitHub stats and links */}
+        <div className="project-card-footer">
+          {project.github && (
+            <div className="github-stats">
+              {project.github.stars !== undefined && (
+                <span className="stat">
+                  <svg
+                    viewBox="0 0 16 16"
+                    width="14"
+                    height="14"
+                    fill="currentColor"
+                  >
+                    <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+                  </svg>
+                  {project.github.stars}
+                </span>
+              )}
+              {project.github.lastCommit && (
+                <span className="stat updated">
+                  updated {formatRelativeDate(project.github.lastCommit)}
+                </span>
+              )}
+            </div>
+          )}
+
+          <div className="project-links">
+            {project.links.slice(0, 3).map(link => (
+              <button
+                key={`${link.type}-${link.url}`}
+                className="link-button"
+                onClick={e => handleLinkClick(e, link.url)}
+                title={link.label || linkLabels[link.type]}
+              >
+                {linkIcons[link.type]}
+                <span className="link-label">
+                  {link.label || linkLabels[link.type]}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+// Helper to format relative dates
+function formatRelativeDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
+  if (diffDays < 365) return `${Math.floor(diffDays / 30)} months ago`;
+  return `${Math.floor(diffDays / 365)} years ago`;
+}
+
+export default ProjectCard;

--- a/src/components/projects/ProjectFilters.tsx
+++ b/src/components/projects/ProjectFilters.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import type { ProjectCategory, ProjectStatus } from '../../config/projects';
+import { categoryConfig, statusConfig } from '../../config/projects';
+
+interface ProjectFiltersProps {
+  selectedCategory: ProjectCategory | null;
+  selectedStatus: ProjectStatus | null;
+  searchTerm: string;
+  onCategoryChange: (category: ProjectCategory | null) => void;
+  onStatusChange: (status: ProjectStatus | null) => void;
+  onSearchChange: (search: string) => void;
+  onClearFilters: () => void;
+  availableCategories: ProjectCategory[];
+  availableStatuses: ProjectStatus[];
+  resultCount: number;
+  totalCount: number;
+}
+
+const ProjectFilters: React.FC<ProjectFiltersProps> = ({
+  selectedCategory,
+  selectedStatus,
+  searchTerm,
+  onCategoryChange,
+  onStatusChange,
+  onSearchChange,
+  onClearFilters,
+  availableCategories,
+  availableStatuses,
+  resultCount,
+  totalCount,
+}) => {
+  const hasActiveFilters =
+    selectedCategory !== null || selectedStatus !== null || searchTerm !== '';
+
+  return (
+    <div className="project-filters">
+      <div className="filters-row">
+        {/* Category dropdown */}
+        <div className="filter-group">
+          <label htmlFor="category-filter" className="filter-label">
+            category
+          </label>
+          <select
+            id="category-filter"
+            className="filter-select"
+            value={selectedCategory || ''}
+            onChange={e =>
+              onCategoryChange(
+                e.target.value ? (e.target.value as ProjectCategory) : null
+              )
+            }
+          >
+            <option value="">all categories</option>
+            {availableCategories.map(cat => (
+              <option key={cat} value={cat}>
+                {categoryConfig[cat].label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Status dropdown */}
+        <div className="filter-group">
+          <label htmlFor="status-filter" className="filter-label">
+            status
+          </label>
+          <select
+            id="status-filter"
+            className="filter-select"
+            value={selectedStatus || ''}
+            onChange={e =>
+              onStatusChange(
+                e.target.value ? (e.target.value as ProjectStatus) : null
+              )
+            }
+          >
+            <option value="">all statuses</option>
+            {availableStatuses.map(status => (
+              <option key={status} value={status}>
+                {statusConfig[status].label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Search input */}
+        <div className="filter-group search-group">
+          <label htmlFor="search-filter" className="filter-label">
+            search
+          </label>
+          <div className="search-input-wrapper">
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="currentColor"
+              className="search-icon"
+            >
+              <path d="M10.68 11.74a6 6 0 0 1-7.922-8.982 6 6 0 0 1 8.982 7.922l3.04 3.04a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215ZM11.5 7a4.499 4.499 0 1 0-8.997 0A4.499 4.499 0 0 0 11.5 7Z" />
+            </svg>
+            <input
+              id="search-filter"
+              type="text"
+              className="filter-input"
+              placeholder="search projects..."
+              value={searchTerm}
+              onChange={e => onSearchChange(e.target.value)}
+            />
+            {searchTerm && (
+              <button
+                className="clear-search"
+                onClick={() => onSearchChange('')}
+                aria-label="Clear search"
+              >
+                <svg
+                  viewBox="0 0 16 16"
+                  width="12"
+                  height="12"
+                  fill="currentColor"
+                >
+                  <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Results count and clear button */}
+      <div className="filters-footer">
+        <span className="results-count">
+          showing {resultCount} of {totalCount} projects
+        </span>
+        {hasActiveFilters && (
+          <button className="clear-filters-btn" onClick={onClearFilters}>
+            clear filters
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProjectFilters;

--- a/src/components/projects/ProjectModal.tsx
+++ b/src/components/projects/ProjectModal.tsx
@@ -1,0 +1,216 @@
+import React, { useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import type { Project, ProjectLinkType } from '../../config/projects';
+import { categoryConfig, statusConfig } from '../../config/projects';
+
+interface ProjectModalProps {
+  project: Project | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Link type icons and labels (same as in ProjectCard)
+const linkIcons: Record<ProjectLinkType, React.ReactNode> = {
+  github: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
+    </svg>
+  ),
+  docs: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75Zm7.251 10.324.004-5.073-.002-2.253A2.25 2.25 0 0 0 5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574ZM8.755 4.75l-.004 7.322a3.752 3.752 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25Z" />
+    </svg>
+  ),
+  blog: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="m11.28 3.22 4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L13.94 8l-3.72-3.72a.749.749 0 0 1 .326-1.275.749.749 0 0 1 .734.215Zm-6.56 0a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042L2.06 8l3.72 3.72a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L.47 8.53a.75.75 0 0 1 0-1.06Z" />
+    </svg>
+  ),
+  demo: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25Zm1.75-.25a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25ZM8 10a2 2 0 1 1-.001-3.999A2 2 0 0 1 8 10Z" />
+    </svg>
+  ),
+  paper: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M0 1.75A.75.75 0 0 1 .75 1h4.253c1.227 0 2.317.59 3 1.501A3.743 3.743 0 0 1 11.006 1h4.245a.75.75 0 0 1 .75.75v10.5a.75.75 0 0 1-.75.75h-4.507a2.25 2.25 0 0 0-1.591.659l-.622.621a.75.75 0 0 1-1.06 0l-.622-.621A2.25 2.25 0 0 0 5.258 13H.75a.75.75 0 0 1-.75-.75ZM5.003 2.5H1.5v9h3.757a3.75 3.75 0 0 1 1.994.574V2.75a2.25 2.25 0 0 0-2.25-2.25Zm3.247 9.572a3.75 3.75 0 0 1 1.992-.572H14.5v-9h-3.495a2.25 2.25 0 0 0-2.25 2.25l-.005 7.322Z" />
+    </svg>
+  ),
+  npm: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M0 0v16h16V0H0zm13 13H8v-2H5v2H3V3h10v10zm-5-7H5v5h3V6zm5 0h-3v5h1V7h1v4h1V6z" />
+    </svg>
+  ),
+  crates: (
+    <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
+      <path d="M8 0L0 4v8l8 4 8-4V4L8 0zm6.5 4.5L8 8 1.5 4.5 8 1l6.5 3.5zM1 5.5l6.5 3.25V15L1 11.5V5.5zm7.5 9.5V8.75L15 5.5v6l-6.5 3.5z" />
+    </svg>
+  ),
+};
+
+const linkLabels: Record<ProjectLinkType, string> = {
+  github: 'GitHub',
+  docs: 'Documentation',
+  blog: 'Blog Post',
+  demo: 'Live Demo',
+  paper: 'Paper',
+  npm: 'npm',
+  crates: 'crates.io',
+};
+
+const ProjectModal: React.FC<ProjectModalProps> = ({
+  project,
+  isOpen,
+  onClose,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+
+  // Handle escape key and focus trap
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElement.current = document.activeElement as HTMLElement;
+      modalRef.current?.focus();
+
+      const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+      };
+
+      document.addEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = 'hidden';
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = '';
+        previousActiveElement.current?.focus();
+      };
+    }
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !project) return null;
+
+  const categoryStyle = categoryConfig[project.category];
+  const statusStyle = statusConfig[project.status];
+
+  return (
+    <div
+      className="project-modal-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      <div
+        ref={modalRef}
+        className="project-modal"
+        onClick={e => e.stopPropagation()}
+        tabIndex={-1}
+      >
+        {/* Close button */}
+        <button
+          className="modal-close"
+          onClick={onClose}
+          aria-label="Close modal"
+        >
+          <svg viewBox="0 0 16 16" width="20" height="20" fill="currentColor">
+            <path d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z" />
+          </svg>
+        </button>
+
+        {/* Header */}
+        <div className="modal-header">
+          <div className="modal-badges">
+            <span
+              className="category-badge"
+              style={{ backgroundColor: categoryStyle.color }}
+            >
+              {categoryStyle.label}
+            </span>
+            {project.status !== 'stable' && (
+              <span
+                className="status-badge"
+                style={{ color: statusStyle.color }}
+              >
+                <span
+                  className="status-dot"
+                  style={{ backgroundColor: statusStyle.color }}
+                />
+                {statusStyle.label}
+              </span>
+            )}
+            {project.year && <span className="year-badge">{project.year}</span>}
+          </div>
+
+          <h2 id="modal-title" className="modal-title">
+            {project.name}
+          </h2>
+          <p className="modal-tagline">{project.tagline}</p>
+        </div>
+
+        {/* Fork info */}
+        {project.upstream && (
+          <div className="modal-fork-info">
+            <span>fork of </span>
+            <a
+              href={project.upstream.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {project.upstream.name}
+            </a>
+            {project.forkReason && <span> — {project.forkReason}</span>}
+          </div>
+        )}
+
+        {/* Description */}
+        <div className="modal-description">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {project.description}
+          </ReactMarkdown>
+        </div>
+
+        {/* Highlights */}
+        {project.highlights && project.highlights.length > 0 && (
+          <div className="modal-highlights">
+            <h3>highlights</h3>
+            <ul>
+              {project.highlights.map((highlight, index) => (
+                <li key={index}>{highlight}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Tags */}
+        <div className="modal-tags">
+          {project.tags.map(tag => (
+            <span key={tag} className="project-tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        {/* Links */}
+        <div className="modal-links">
+          {project.links.map(link => (
+            <a
+              key={`${link.type}-${link.url}`}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="modal-link-button"
+            >
+              {linkIcons[link.type]}
+              <span>{link.label || linkLabels[link.type]}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectModal;

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,0 +1,3 @@
+export { default as ProjectCard } from './ProjectCard';
+export { default as ProjectModal } from './ProjectModal';
+export { default as ProjectFilters } from './ProjectFilters';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -4,4 +4,5 @@ export * from './constants';
 export * from './cv';
 export * from './helpers';
 export * from './homepage';
+export * from './projects';
 export * from './site';

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1,74 +1,471 @@
-export interface GitHubProject {
-  name: string;
-  description: string;
-  language: string;
-  tags: string[];
+// Project Categories
+export type ProjectCategory =
+  | 'library'
+  | 'infrastructure'
+  | 'application'
+  | 'experiment'
+  | 'tool'
+  | 'fork'
+  | 'research';
+
+// Project Status
+export type ProjectStatus = 'active' | 'stable' | 'archived';
+
+// Link Types
+export type ProjectLinkType =
+  | 'github'
+  | 'docs'
+  | 'blog'
+  | 'demo'
+  | 'paper'
+  | 'npm'
+  | 'crates';
+
+export interface ProjectLink {
+  type: ProjectLinkType;
   url: string;
+  label?: string;
+}
+
+export interface GitHubMetadata {
+  repo: string; // "owner/repo" format
   stars?: number;
-  featured?: boolean;
+  lastCommit?: string;
+}
+
+export interface UpstreamInfo {
+  name: string;
+  url: string;
+}
+
+export interface Project {
+  // Identity
+  id: string;
+  name: string;
+  tagline: string;
+
+  // Classification
+  category: ProjectCategory;
+  status: ProjectStatus;
+  featured: boolean;
+
+  // Content
+  description: string;
+  highlights?: string[];
+
+  // Links
+  links: ProjectLink[];
+
+  // Metadata
+  tags: string[];
+  year?: number;
+
+  // Fork-specific
+  upstream?: UpstreamInfo;
+  forkReason?: string;
+
+  // GitHub metadata
+  github?: GitHubMetadata;
 }
 
 export interface ProjectsConfig {
   title: string;
   subtitle: string;
-  projects: GitHubProject[];
+  projects: Project[];
 }
+
+// Category display configuration
+export const categoryConfig: Record<
+  ProjectCategory,
+  { label: string; color: string }
+> = {
+  library: { label: 'library', color: '#3178c6' }, // blue
+  infrastructure: { label: 'infrastructure', color: '#9c27b0' }, // purple
+  application: { label: 'application', color: '#00a854' }, // green
+  experiment: { label: 'experiment', color: '#ff9800' }, // orange
+  tool: { label: 'tool', color: '#6e7681' }, // gray
+  fork: { label: 'fork', color: '#00acc1' }, // teal
+  research: { label: 'research', color: '#5c6bc0' }, // indigo
+};
+
+// Status display configuration
+export const statusConfig: Record<
+  ProjectStatus,
+  { label: string; color: string }
+> = {
+  active: { label: 'active', color: '#00a854' },
+  stable: { label: 'stable', color: '#6e7681' },
+  archived: { label: 'archived', color: '#9e9e9e' },
+};
 
 export const projectsConfig: ProjectsConfig = {
   title: 'projects',
   subtitle:
-    'a collection of open source projects, experiments, and tools i\'ve built or contributed to.',
+    'i build systems where elegant abstractions compose into complex behavior through well-governed local rules.',
   projects: [
+    // Featured Projects
     {
-      name: 'alexnodeland',
-      description:
-        'my personal website built with gatsby, featuring a retro-futuristic design, ai chat integration, and animated three.js backgrounds.',
-      language: 'TypeScript',
-      tags: ['gatsby', 'react', 'three.js', 'scss', 'personal-site'],
-      url: 'https://github.com/alexnodeland/alexnodeland',
+      id: 'fugue',
+      name: 'Fugue',
+      tagline: 'monadic probabilistic programming for rust',
+      category: 'library',
+      status: 'active',
       featured: true,
+      description: `
+Fugue is a production-ready, monadic probabilistic programming library for Rust that enables expressive, type-safe probabilistic modeling.
+
+## Architecture
+
+The library uses a defunctionalized CPS monad implementation that enables composable probabilistic computations while maintaining Rust's safety guarantees.
+
+## Inference Methods
+
+- MCMC (Metropolis-Hastings, HMC)
+- SMC (Sequential Monte Carlo)
+- Variational Inference
+- Approximate Bayesian Computation (ABC)
+
+The design prioritizes ergonomics without sacrificing performance, making it suitable for both research prototyping and production deployment.
+      `.trim(),
+      highlights: [
+        'Defunctionalized CPS monad implementation',
+        'Type-safe probabilistic programming',
+        'Multiple inference backends (MCMC, SMC, VI, ABC)',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/fugue' },
+        { type: 'crates', url: 'https://crates.io/crates/fugue' },
+      ],
+      tags: ['rust', 'probabilistic-programming', 'monads', 'mcmc', 'bayesian'],
+      year: 2025,
+      github: { repo: 'alexnodeland/fugue' },
     },
     {
-      name: 'ai-engineering-hub',
-      description:
-        'curated collection of resources, patterns, and best practices for building production-ready ai systems and llm applications.',
-      language: 'Python',
-      tags: ['ai', 'llm', 'machine-learning', 'best-practices'],
-      url: 'https://github.com/alexnodeland/ai-engineering-hub',
+      id: 'fugue-evo',
+      name: 'Fugue-evo',
+      tagline: 'evolutionary algorithms built on fugue primitives',
+      category: 'library',
+      status: 'active',
       featured: true,
+      description: `
+Fugue-evo extends the Fugue probabilistic programming library with evolutionary computation primitives.
+
+## Features
+
+- Genetic algorithms with configurable selection, crossover, and mutation operators
+- Evolution strategies (CMA-ES, Natural Evolution Strategies)
+- Multi-objective optimization (NSGA-II, MOEA/D)
+- Seamless integration with Fugue's probabilistic primitives
+
+Built on the same compositional philosophy as Fugue, enabling hybrid probabilistic-evolutionary approaches.
+      `.trim(),
+      highlights: [
+        'Genetic algorithms with pluggable operators',
+        'Evolution strategies (CMA-ES, NES)',
+        'Multi-objective optimization support',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/fugue-evo' },
+      ],
+      tags: ['rust', 'evolutionary-algorithms', 'optimization', 'genetic-algorithms'],
+      year: 2025,
+      github: { repo: 'alexnodeland/fugue-evo' },
     },
     {
-      name: 'rag-patterns',
-      description:
-        'reference implementations and architectural patterns for retrieval-augmented generation systems.',
-      language: 'Python',
-      tags: ['rag', 'llm', 'vector-search', 'embeddings'],
-      url: 'https://github.com/alexnodeland/rag-patterns',
+      id: 'quiver',
+      name: 'Quiver',
+      tagline: 'composable agent framework for llm orchestration',
+      category: 'library',
+      status: 'active',
       featured: true,
+      description: `
+Quiver is a composable agent framework designed for building complex LLM-powered systems through simple, well-defined primitives.
+
+## Design Philosophy
+
+Rather than providing a monolithic agent architecture, Quiver offers building blocks that compose naturally:
+
+- **Arrows**: Typed, composable computation units
+- **Contexts**: Scoped state and capability management
+- **Flows**: DAG-based workflow orchestration
+
+## Key Features
+
+- Type-safe agent composition
+- Built-in observability and tracing
+- Flexible tool integration
+- Support for multi-agent coordination
+      `.trim(),
+      highlights: [
+        'Arrow-based composable computation model',
+        'DAG workflow orchestration',
+        'Type-safe agent composition',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/quiver' },
+      ],
+      tags: ['python', 'llm', 'agents', 'orchestration', 'composition'],
+      year: 2025,
+      github: { repo: 'alexnodeland/quiver' },
     },
     {
-      name: 'workflow-orchestrator',
-      description:
-        'dag-based workflow orchestration framework for complex multi-step ai agent pipelines.',
-      language: 'Python',
-      tags: ['workflow', 'dag', 'orchestration', 'ai-agents'],
-      url: 'https://github.com/alexnodeland/workflow-orchestrator',
+      id: 'principled',
+      name: 'Principled',
+      tagline: 'opinionated project templates for structured development',
+      category: 'infrastructure',
+      status: 'active',
+      featured: true,
+      description: `
+Principled provides opinionated project templates that encode best practices for structured software development.
+
+## Available Templates
+
+- **Python**: Poetry-based setup with pytest, mypy, ruff, pre-commit hooks
+- **Rust**: Cargo workspace with clippy, rustfmt, CI/CD
+- **TypeScript**: pnpm monorepo with ESLint, Prettier, Vitest
+
+## Philosophy
+
+Each template embodies the principle that good defaults and clear conventions reduce cognitive load and enable faster iteration without sacrificing quality.
+      `.trim(),
+      highlights: [
+        'Battle-tested project templates',
+        'Integrated CI/CD configurations',
+        'Pre-configured linting and formatting',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/principled' },
+      ],
+      tags: ['templates', 'devops', 'python', 'rust', 'typescript', 'ci-cd'],
+      year: 2025,
+      github: { repo: 'alexnodeland/principled' },
     },
     {
-      name: 'devops-templates',
-      description:
-        'collection of infrastructure as code templates for aws, docker, and kubernetes deployments.',
-      language: 'HCL',
-      tags: ['terraform', 'docker', 'kubernetes', 'aws', 'iac'],
-      url: 'https://github.com/alexnodeland/devops-templates',
+      id: 'artifactr',
+      name: 'Artifactr',
+      tagline: 'artifact management for ml experiments and pipelines',
+      category: 'infrastructure',
+      status: 'active',
+      featured: true,
+      description: `
+Artifactr provides a unified interface for managing artifacts across ML experiments and data pipelines.
+
+## Features
+
+- **Versioned artifacts**: Track models, datasets, and intermediate results
+- **Storage backends**: S3, GCS, local filesystem, with pluggable backends
+- **Lineage tracking**: Automatic provenance for reproducibility
+- **Integration**: Works with MLflow, Weights & Biases, or standalone
+
+## Design Goals
+
+Minimize boilerplate while maintaining full control over artifact lifecycle and storage strategy.
+      `.trim(),
+      highlights: [
+        'Unified artifact versioning and tracking',
+        'Pluggable storage backends',
+        'Automatic lineage and provenance',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/artifactr' },
+      ],
+      tags: ['python', 'mlops', 'artifacts', 'ml-pipelines', 'data-engineering'],
+      year: 2025,
+      github: { repo: 'alexnodeland/artifactr' },
+    },
+
+    // Experiments
+    {
+      id: 'finance-crew',
+      name: 'Finance Crew',
+      tagline: 'multi-agent financial analysis with crewai',
+      category: 'experiment',
+      status: 'archived',
+      featured: false,
+      description: `
+An experimental multi-agent system for financial analysis built with CrewAI.
+
+Demonstrates coordinated agents performing market research, fundamental analysis, and report generation. Served as a learning exercise for multi-agent orchestration patterns.
+      `.trim(),
+      highlights: [
+        'Multi-agent coordination patterns',
+        'Financial data integration',
+        'Automated report generation',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/finance-crew' },
+        { type: 'blog', url: '/blog/finance-crew' },
+      ],
+      tags: ['python', 'crewai', 'agents', 'finance', 'llm'],
+      year: 2024,
+      github: { repo: 'alexnodeland/finance-crew' },
     },
     {
-      name: 'signal-processing-toolkit',
-      description:
-        'numerical methods and algorithms for audio signal processing and compression.',
-      language: 'Python',
-      tags: ['dsp', 'audio', 'wavelets', 'compression'],
-      url: 'https://github.com/alexnodeland/signal-processing-toolkit',
+      id: 'crewlit',
+      name: 'Crewlit',
+      tagline: 'literature review automation with agent crews',
+      category: 'experiment',
+      status: 'archived',
+      featured: false,
+      description: `
+Automated literature review system using multi-agent collaboration.
+
+Agents coordinate to search papers, extract key findings, identify themes, and synthesize summaries. An exploration of agent-based knowledge work automation.
+      `.trim(),
+      highlights: [
+        'Paper search and retrieval agents',
+        'Automated theme extraction',
+        'Synthesis and summarization',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/crewlit' },
+        { type: 'blog', url: '/blog/crewlit' },
+      ],
+      tags: ['python', 'crewai', 'agents', 'research', 'literature-review'],
+      year: 2024,
+      github: { repo: 'alexnodeland/crewlit' },
+    },
+    {
+      id: 'resume-crew',
+      name: 'Resume Crew',
+      tagline: 'ai-powered resume tailoring with agent collaboration',
+      category: 'experiment',
+      status: 'archived',
+      featured: false,
+      description: `
+Multi-agent system for tailoring resumes to job descriptions.
+
+Agents analyze job postings, identify relevant experience, and suggest resume modifications. A practical exploration of agent coordination for document generation tasks.
+      `.trim(),
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/resume-crew' },
+        { type: 'blog', url: '/blog/resume-crew' },
+      ],
+      tags: ['python', 'crewai', 'agents', 'resume', 'nlp'],
+      year: 2024,
+      github: { repo: 'alexnodeland/resume-crew' },
+    },
+    {
+      id: 'vanilla-react',
+      name: 'Vanilla ReAct',
+      tagline: 'minimal react agent implementation from scratch',
+      category: 'experiment',
+      status: 'archived',
+      featured: false,
+      description: `
+A minimal implementation of the ReAct (Reasoning + Acting) agent pattern without external frameworks.
+
+Built to understand the core mechanics of tool-using agents: thought generation, action selection, observation processing, and iterative refinement.
+      `.trim(),
+      highlights: [
+        'Pure Python implementation',
+        'Clear ReAct loop mechanics',
+        'Educational codebase',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/vanilla-react' },
+        { type: 'blog', url: '/blog/vanilla-react' },
+      ],
+      tags: ['python', 'agents', 'react', 'llm', 'from-scratch'],
+      year: 2024,
+      github: { repo: 'alexnodeland/vanilla-react' },
+    },
+    {
+      id: 'qcsim',
+      name: 'QCSim',
+      tagline: 'quantum circuit simulator for learning and exploration',
+      category: 'experiment',
+      status: 'archived',
+      featured: false,
+      description: `
+A simple quantum circuit simulator built for learning quantum computing fundamentals.
+
+Implements basic gates, state vectors, and measurement. Useful for understanding quantum mechanics without the complexity of production simulators.
+      `.trim(),
+      highlights: [
+        'Basic quantum gate implementations',
+        'State vector simulation',
+        'Educational quantum computing',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/qcsim' },
+        { type: 'blog', url: '/blog/qcsim' },
+      ],
+      tags: ['python', 'quantum-computing', 'simulation', 'education'],
+      year: 2024,
+      github: { repo: 'alexnodeland/qcsim' },
+    },
+    {
+      id: 'algorithm-visualizations',
+      name: 'Algorithm Visualizations',
+      tagline: 'interactive visualizations of classic algorithms',
+      category: 'experiment',
+      status: 'stable',
+      featured: false,
+      description: `
+A collection of interactive algorithm visualizations for educational purposes.
+
+Covers sorting algorithms, graph traversals, dynamic programming, and more. Built with vanilla JavaScript and Canvas for accessibility and simplicity.
+      `.trim(),
+      links: [{ type: 'blog', url: '/blog/algorithm-visualizations' }],
+      tags: ['javascript', 'algorithms', 'visualization', 'education'],
+      year: 2023,
+    },
+
+    // Research
+    {
+      id: 'wavelet-research',
+      name: 'Wavelet Audio Compression',
+      tagline: 'research on optimal wavelet bases for audio signals',
+      category: 'research',
+      status: 'archived',
+      featured: false,
+      description: `
+Graduate research on optimal wavelet bases for audio compression conducted at Stony Brook University.
+
+Investigated the trade-offs between different wavelet families for audio signal representation, focusing on perceptual quality metrics and compression ratios.
+      `.trim(),
+      highlights: [
+        'Wavelet basis optimization for audio',
+        'Perceptual quality metrics',
+        'High-performance computing implementation',
+      ],
+      links: [{ type: 'blog', url: '/blog/wavelet-research' }],
+      tags: [
+        'signal-processing',
+        'wavelets',
+        'audio',
+        'compression',
+        'research',
+      ],
+      year: 2017,
+    },
+
+    // Personal site
+    {
+      id: 'alexnodeland',
+      name: 'alexnodeland.com',
+      tagline: 'personal website with retro-futuristic design',
+      category: 'application',
+      status: 'active',
+      featured: false,
+      description: `
+My personal website built with Gatsby, featuring a retro-futuristic design aesthetic.
+
+Includes an AI chat integration, animated Three.js backgrounds, and a comprehensive CV section with export capabilities.
+      `.trim(),
+      highlights: [
+        'Gatsby + React + TypeScript',
+        'Three.js animated backgrounds',
+        'AI chat integration',
+      ],
+      links: [
+        { type: 'github', url: 'https://github.com/alexnodeland/alexnodeland' },
+        { type: 'demo', url: 'https://alexnodeland.com' },
+      ],
+      tags: ['gatsby', 'react', 'typescript', 'three.js', 'scss'],
+      year: 2024,
+      github: { repo: 'alexnodeland/alexnodeland' },
     },
   ],
 };
@@ -97,4 +494,18 @@ export const getLanguageColor = (language: string): string => {
   };
 
   return colors[language] || '#6e7681';
+};
+
+// Helper to get all unique categories from projects
+export const getProjectCategories = (): ProjectCategory[] => {
+  const categories = new Set<ProjectCategory>();
+  projectsConfig.projects.forEach(p => categories.add(p.category));
+  return Array.from(categories);
+};
+
+// Helper to get all unique statuses from projects
+export const getProjectStatuses = (): ProjectStatus[] => {
+  const statuses = new Set<ProjectStatus>();
+  projectsConfig.projects.forEach(p => statuses.add(p.status));
+  return Array.from(statuses);
 };

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -1,0 +1,100 @@
+export interface GitHubProject {
+  name: string;
+  description: string;
+  language: string;
+  tags: string[];
+  url: string;
+  stars?: number;
+  featured?: boolean;
+}
+
+export interface ProjectsConfig {
+  title: string;
+  subtitle: string;
+  projects: GitHubProject[];
+}
+
+export const projectsConfig: ProjectsConfig = {
+  title: 'projects',
+  subtitle:
+    'a collection of open source projects, experiments, and tools i\'ve built or contributed to.',
+  projects: [
+    {
+      name: 'alexnodeland',
+      description:
+        'my personal website built with gatsby, featuring a retro-futuristic design, ai chat integration, and animated three.js backgrounds.',
+      language: 'TypeScript',
+      tags: ['gatsby', 'react', 'three.js', 'scss', 'personal-site'],
+      url: 'https://github.com/alexnodeland/alexnodeland',
+      featured: true,
+    },
+    {
+      name: 'ai-engineering-hub',
+      description:
+        'curated collection of resources, patterns, and best practices for building production-ready ai systems and llm applications.',
+      language: 'Python',
+      tags: ['ai', 'llm', 'machine-learning', 'best-practices'],
+      url: 'https://github.com/alexnodeland/ai-engineering-hub',
+      featured: true,
+    },
+    {
+      name: 'rag-patterns',
+      description:
+        'reference implementations and architectural patterns for retrieval-augmented generation systems.',
+      language: 'Python',
+      tags: ['rag', 'llm', 'vector-search', 'embeddings'],
+      url: 'https://github.com/alexnodeland/rag-patterns',
+      featured: true,
+    },
+    {
+      name: 'workflow-orchestrator',
+      description:
+        'dag-based workflow orchestration framework for complex multi-step ai agent pipelines.',
+      language: 'Python',
+      tags: ['workflow', 'dag', 'orchestration', 'ai-agents'],
+      url: 'https://github.com/alexnodeland/workflow-orchestrator',
+    },
+    {
+      name: 'devops-templates',
+      description:
+        'collection of infrastructure as code templates for aws, docker, and kubernetes deployments.',
+      language: 'HCL',
+      tags: ['terraform', 'docker', 'kubernetes', 'aws', 'iac'],
+      url: 'https://github.com/alexnodeland/devops-templates',
+    },
+    {
+      name: 'signal-processing-toolkit',
+      description:
+        'numerical methods and algorithms for audio signal processing and compression.',
+      language: 'Python',
+      tags: ['dsp', 'audio', 'wavelets', 'compression'],
+      url: 'https://github.com/alexnodeland/signal-processing-toolkit',
+    },
+  ],
+};
+
+// Helper function to get language color (GitHub-style)
+export const getLanguageColor = (language: string): string => {
+  const colors: Record<string, string> = {
+    TypeScript: '#3178c6',
+    JavaScript: '#f1e05a',
+    Python: '#3572A5',
+    Go: '#00ADD8',
+    Rust: '#dea584',
+    HCL: '#844fba',
+    Shell: '#89e051',
+    Java: '#b07219',
+    'C++': '#f34b7d',
+    C: '#555555',
+    Ruby: '#701516',
+    PHP: '#4F5D95',
+    Swift: '#F05138',
+    Kotlin: '#A97BFF',
+    Scala: '#c22d40',
+    HTML: '#e34c26',
+    CSS: '#563d7c',
+    SCSS: '#c6538c',
+  };
+
+  return colors[language] || '#6e7681';
+};

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -91,6 +91,7 @@ export const siteConfig: SiteConfig = {
   navigation: {
     main: [
       { name: 'blog', href: '/blog' },
+      { name: 'projects', href: '/projects' },
       { name: 'cv', href: '/cv' },
     ],
   },

--- a/src/pages/projects.tsx
+++ b/src/pages/projects.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { Layout, SEO } from '../components';
+import { projectsConfig, getLanguageColor } from '../config';
+import type { GitHubProject } from '../config';
+import '../styles/projects.scss';
+
+const ProjectCard: React.FC<{ project: GitHubProject }> = ({ project }) => {
+  const languageColor = getLanguageColor(project.language);
+
+  return (
+    <a
+      href={project.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`project-card ${project.featured ? 'featured' : ''}`}
+    >
+      <div className="project-card-content">
+        <div className="project-header">
+          <div className="project-icon">
+            <svg
+              viewBox="0 0 16 16"
+              width="16"
+              height="16"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8ZM5 12.25a.25.25 0 0 1 .25-.25h3.5a.25.25 0 0 1 .25.25v3.25a.25.25 0 0 1-.4.2l-1.45-1.087a.249.249 0 0 0-.3 0L5.4 15.7a.25.25 0 0 1-.4-.2Z" />
+            </svg>
+          </div>
+          <h3 className="project-name">{project.name}</h3>
+          {project.featured && <span className="featured-badge">featured</span>}
+        </div>
+
+        <p className="project-description">{project.description}</p>
+
+        <div className="project-tags">
+          {project.tags.map(tag => (
+            <span key={tag} className="project-tag">
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="project-footer">
+          <div className="project-language">
+            <span
+              className="language-dot"
+              style={{ backgroundColor: languageColor }}
+            />
+            <span className="language-name">{project.language}</span>
+          </div>
+          <div className="project-link-indicator">
+            <span>view on github</span>
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M3.75 2h3.5a.75.75 0 0 1 0 1.5h-2.19l5.22 5.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L4 4.81v2.19a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 3.25 2.75Zm6.5-1h4.25a.75.75 0 0 1 .75.75v4.25a.75.75 0 0 1-1.5 0V3.56l-5.22 5.22a.749.749 0 0 1-1.06-1.06L12.69 2.5h-2.44a.75.75 0 0 1 0-1.5Z" />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </a>
+  );
+};
+
+const ProjectsPage: React.FC = () => {
+  const featuredProjects = projectsConfig.projects.filter(p => p.featured);
+  const otherProjects = projectsConfig.projects.filter(p => !p.featured);
+
+  return (
+    <Layout>
+      <SEO
+        title="projects"
+        description="open source projects, experiments, and tools by alex nodeland"
+      />
+      <div className="projects-page">
+        <header className="projects-header">
+          <h1>{projectsConfig.title}</h1>
+          <p>{projectsConfig.subtitle}</p>
+        </header>
+
+        {featuredProjects.length > 0 && (
+          <section className="projects-section">
+            <h2 className="section-title">featured</h2>
+            <div className="projects-grid featured-grid">
+              {featuredProjects.map(project => (
+                <ProjectCard key={project.name} project={project} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {otherProjects.length > 0 && (
+          <section className="projects-section">
+            <h2 className="section-title">more projects</h2>
+            <div className="projects-grid">
+              {otherProjects.map(project => (
+                <ProjectCard key={project.name} project={project} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="github-cta">
+          <p>want to see more?</p>
+          <a
+            href="https://github.com/alexnodeland"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="github-link"
+          >
+            <svg
+              viewBox="0 0 16 16"
+              width="20"
+              height="20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z" />
+            </svg>
+            <span>view all repositories on github</span>
+          </a>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default ProjectsPage;

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -1,10 +1,10 @@
 .projects-page {
-  max-width: 1100px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 0 1rem 3rem;
 }
 
-// Projects Page Header (matching blog/cv pattern)
+// Projects Page Header
 .projects-header {
   text-align: center;
   margin-bottom: 3rem;
@@ -41,7 +41,7 @@
     font-size: 1.1rem;
     line-height: 1.6;
     font-style: italic;
-    max-width: 600px;
+    max-width: 700px;
     margin: 0 auto;
   }
 }
@@ -68,21 +68,27 @@
 // Projects Grid
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.5rem;
 
   &.featured-grid {
     grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   }
+
+  &.catalog-grid {
+    margin-top: 1.5rem;
+  }
 }
 
-// Project Card
+// ============================================
+// PROJECT CARD STYLES
+// ============================================
+
 .project-card {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border-color);
-  text-decoration: none;
-  display: block;
+  cursor: pointer;
   position: relative;
   box-shadow: 0 0 20px rgba(0, 255, 136, 0.05);
   transition: all var(--transition-normal);
@@ -106,7 +112,8 @@
     transition: opacity var(--transition-normal);
   }
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     transform: translateY(-4px);
     box-shadow: 0 8px 30px rgba(0, 255, 136, 0.15);
     border-color: var(--border-active);
@@ -114,14 +121,11 @@
     &::before {
       opacity: 1;
     }
+  }
 
-    .project-link-indicator {
-      color: var(--primary-color);
-
-      svg {
-        transform: translate(2px, -2px);
-      }
-    }
+  &:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
   }
 
   &.featured {
@@ -136,6 +140,14 @@
       height: 3px;
     }
   }
+
+  &.archived {
+    opacity: 0.7;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
 }
 
 .project-card-content {
@@ -143,74 +155,90 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-height: 220px;
+  min-height: 240px;
 }
 
-.project-header {
+.project-card-header {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.project-icon {
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-}
-
-.project-name {
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0;
-  font-family:
-    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
-    monospace;
-  text-transform: lowercase;
-  letter-spacing: -0.01em;
-  flex: 1;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.featured-badge {
+.category-badge {
   font-size: 0.7rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 0.25rem 0.5rem;
-  background: linear-gradient(135deg, var(--accent-pink), var(--accent-purple));
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+  padding: 0.25rem 0.6rem;
   color: white;
   border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
 
-.project-description {
+.status-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: lowercase;
+}
+
+.status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.project-name {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 0.5rem;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  letter-spacing: -0.01em;
+}
+
+.project-tagline {
   font-size: 0.95rem;
   color: var(--text-secondary);
-  line-height: 1.6;
+  line-height: 1.5;
   margin: 0 0 1rem;
   flex: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+}
+
+.fork-info {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0 0 0.75rem;
+  font-style: italic;
+
+  a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }
 
 .project-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.4rem;
   margin-bottom: 1rem;
 }
 
 .project-tag {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.6rem;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
   background: var(--bg-accent);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-sm);
@@ -219,61 +247,545 @@
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
   text-transform: lowercase;
-  transition: all var(--transition-fast);
 
-  .project-card:hover & {
-    border-color: var(--border-active);
+  &.more {
+    color: var(--text-muted);
+    font-style: italic;
   }
 }
 
-.project-footer {
+.project-card-footer {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
+  gap: 0.75rem;
   margin-top: auto;
   padding-top: 1rem;
   border-top: 1px solid var(--border-color);
 }
 
-.project-language {
+.github-stats {
   display: flex;
   align-items: center;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+
+  .stat {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+
+    svg {
+      color: var(--accent-yellow);
+    }
+
+    &.updated {
+      color: var(--text-secondary);
+    }
+  }
+}
+
+.project-links {
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.language-dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  flex-shrink: 0;
-}
-
-.language-name {
-  font-size: 0.85rem;
+.link-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.7rem;
+  background: var(--bg-accent);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
+  font-size: 0.75rem;
   font-family:
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+  }
+
+  .link-label {
+    display: none;
+
+    @media (min-width: 400px) {
+      display: inline;
+    }
+  }
 }
 
-.project-link-indicator {
+// ============================================
+// PROJECT FILTERS STYLES
+// ============================================
+
+.project-filters {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  margin-bottom: 0;
+}
+
+.filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 140px;
+
+  &.search-group {
+    flex: 1;
+    min-width: 200px;
+  }
+}
+
+.filter-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+}
+
+.filter-select {
+  padding: 0.6rem 0.75rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    border-color: var(--border-active);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(0, 255, 136, 0.2);
+  }
+}
+
+.search-input-wrapper {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 0.4rem;
+}
+
+.search-icon {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.filter-input {
+  width: 100%;
+  padding: 0.6rem 0.75rem 0.6rem 2.25rem;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  transition: all var(--transition-fast);
+
+  &::placeholder {
+    color: var(--text-muted);
+    text-transform: lowercase;
+  }
+
+  &:hover {
+    border-color: var(--border-active);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 2px rgba(0, 255, 136, 0.2);
+  }
+}
+
+.clear-search {
+  position: absolute;
+  right: 0.5rem;
+  padding: 0.25rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
+.filters-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.results-count {
   font-size: 0.8rem;
   color: var(--text-muted);
   font-family:
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
   text-transform: lowercase;
-  transition: color var(--transition-fast);
+}
 
-  svg {
-    transition: transform var(--transition-fast);
+.clear-filters-btn {
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    border-color: var(--accent-pink);
+    color: var(--accent-pink);
   }
 }
 
-// GitHub CTA Section
+.no-results {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  margin-top: 1.5rem;
+
+  p {
+    color: var(--text-secondary);
+    margin-bottom: 1rem;
+    font-style: italic;
+  }
+}
+
+// ============================================
+// PROJECT MODAL STYLES
+// ============================================
+
+.project-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1rem;
+  animation: fadeIn 0.2s ease-out;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.project-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  max-width: 700px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: slideUp 0.25s ease-out;
+
+  // Gradient top border
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(
+      90deg,
+      var(--accent-pink) 0%,
+      var(--accent-purple) 25%,
+      var(--accent-cyan) 50%,
+      var(--primary-color) 75%,
+      var(--accent-pink) 100%
+    );
+    border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.modal-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.5rem;
+  background: var(--bg-accent);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  z-index: 1;
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    border-color: var(--border-active);
+  }
+}
+
+.modal-header {
+  padding: 2rem 2rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.modal-badges {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.status-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  text-transform: lowercase;
+}
+
+.year-badge {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+}
+
+.modal-title {
+  font-size: 1.75rem;
+  margin: 0 0 0.5rem;
+  color: var(--text-primary);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  letter-spacing: -0.02em;
+}
+
+.modal-tagline {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  margin: 0;
+  font-style: italic;
+}
+
+.modal-fork-info {
+  padding: 1rem 2rem;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+
+  a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.modal-description {
+  padding: 1.5rem 2rem;
+
+  h2 {
+    font-size: 1.25rem;
+    margin: 1.5rem 0 0.75rem;
+    color: var(--text-primary);
+    font-family:
+      'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+      monospace;
+    text-transform: lowercase;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    margin: 1.25rem 0 0.5rem;
+    color: var(--text-primary);
+  }
+
+  p {
+    margin: 0 0 1rem;
+    line-height: 1.7;
+    color: var(--text-secondary);
+  }
+
+  ul,
+  ol {
+    margin: 0 0 1rem;
+    padding-left: 1.5rem;
+    color: var(--text-secondary);
+
+    li {
+      margin-bottom: 0.5rem;
+      line-height: 1.6;
+    }
+  }
+
+  strong {
+    color: var(--text-primary);
+  }
+
+  code {
+    background: var(--bg-accent);
+    padding: 0.15rem 0.4rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.9em;
+    color: var(--accent-cyan);
+  }
+}
+
+.modal-highlights {
+  padding: 0 2rem 1.5rem;
+
+  h3 {
+    font-size: 1rem;
+    margin: 0 0 0.75rem;
+    color: var(--text-primary);
+    font-family:
+      'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+      monospace;
+    text-transform: lowercase;
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+
+    li {
+      margin-bottom: 0.5rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+
+      &::marker {
+        color: var(--primary-color);
+      }
+    }
+  }
+}
+
+.modal-tags {
+  padding: 0 2rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.modal-links {
+  padding: 1.5rem 2rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.modal-link-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-accent);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  transition: all var(--transition-fast);
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+  }
+}
+
+// ============================================
+// GITHUB CTA STYLES
+// ============================================
+
 .github-cta {
   text-align: center;
   padding: 3rem 2rem;
@@ -372,7 +884,7 @@
   }
 }
 
-// Glow animation (shared with other pages)
+// Glow animation
 @keyframes glow {
   from {
     text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
@@ -384,7 +896,10 @@
   }
 }
 
-// Responsive Design
+// ============================================
+// RESPONSIVE DESIGN
+// ============================================
+
 @media (max-width: 768px) {
   .projects-page {
     padding: 0 1rem 2rem;
@@ -416,8 +931,43 @@
     min-height: auto;
   }
 
-  .project-description {
-    -webkit-line-clamp: 4;
+  .filters-row {
+    flex-direction: column;
+  }
+
+  .filter-group {
+    width: 100%;
+  }
+
+  .project-modal {
+    max-height: 95vh;
+    margin: 0.5rem;
+  }
+
+  .modal-header {
+    padding: 1.5rem 1.5rem 1rem;
+  }
+
+  .modal-description {
+    padding: 1rem 1.5rem;
+  }
+
+  .modal-highlights {
+    padding: 0 1.5rem 1rem;
+  }
+
+  .modal-tags {
+    padding: 0 1.5rem 1rem;
+  }
+
+  .modal-links {
+    padding: 1rem 1.5rem;
+    flex-direction: column;
+  }
+
+  .modal-link-button {
+    width: 100%;
+    justify-content: center;
   }
 
   .github-cta {
@@ -432,23 +982,29 @@
 }
 
 @media (max-width: 480px) {
-  .project-header {
+  .project-card-header {
     flex-wrap: wrap;
   }
 
-  .featured-badge {
-    order: 3;
-    width: auto;
-  }
-
-  .project-footer {
+  .project-card-footer {
     flex-direction: column;
     gap: 0.75rem;
-    align-items: flex-start;
+  }
+
+  .project-links {
+    width: 100%;
+  }
+
+  .link-button {
+    flex: 1;
+    justify-content: center;
   }
 }
 
-// Light mode specific enhancements
+// ============================================
+// LIGHT MODE
+// ============================================
+
 [data-theme='light'] {
   .projects-header {
     h1 {
@@ -475,9 +1031,17 @@
     }
   }
 
-  .project-tag {
-    background: var(--bg-hover);
-    border-color: var(--border-color);
+  .project-filters {
+    background: var(--bg-card);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  }
+
+  .project-modal-overlay {
+    background: rgba(0, 0, 0, 0.6);
+  }
+
+  .project-modal {
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   }
 
   .github-cta {

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -1,0 +1,496 @@
+.projects-page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+}
+
+// Projects Page Header (matching blog/cv pattern)
+.projects-header {
+  text-align: center;
+  margin-bottom: 3rem;
+  padding: calc(var(--header-height) + 0.5rem) 0 2rem;
+  position: relative;
+
+  h1 {
+    margin-bottom: 1rem;
+    font-family:
+      'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+      monospace;
+    text-transform: lowercase;
+    letter-spacing: -0.02em;
+    position: relative;
+    text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+    animation: glow 2s ease-in-out infinite alternate;
+
+    &::after {
+      content: '';
+      position: absolute;
+      bottom: -0.5rem;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 60px;
+      height: 3px;
+      background: var(--accent-color);
+      border-radius: 2px;
+      box-shadow: 0 0 10px rgba(255, 0, 128, 0.5);
+    }
+  }
+
+  p {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    line-height: 1.6;
+    font-style: italic;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+}
+
+// Section Titles
+.projects-section {
+  margin-bottom: 3rem;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--accent-cyan);
+  display: inline-block;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+// Projects Grid
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1.5rem;
+
+  &.featured-grid {
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  }
+}
+
+// Project Card
+.project-card {
+  background: var(--bg-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  text-decoration: none;
+  display: block;
+  position: relative;
+  box-shadow: 0 0 20px rgba(0, 255, 136, 0.05);
+  transition: all var(--transition-normal);
+  overflow: hidden;
+
+  // Gradient top border
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: linear-gradient(
+      90deg,
+      var(--accent-cyan) 0%,
+      var(--primary-color) 50%,
+      var(--accent-cyan) 100%
+    );
+    opacity: 0.5;
+    transition: opacity var(--transition-normal);
+  }
+
+  &:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 30px rgba(0, 255, 136, 0.15);
+    border-color: var(--border-active);
+
+    &::before {
+      opacity: 1;
+    }
+
+    .project-link-indicator {
+      color: var(--primary-color);
+
+      svg {
+        transform: translate(2px, -2px);
+      }
+    }
+  }
+
+  &.featured {
+    &::before {
+      background: linear-gradient(
+        90deg,
+        var(--accent-pink) 0%,
+        var(--accent-purple) 33%,
+        var(--accent-cyan) 66%,
+        var(--primary-color) 100%
+      );
+      height: 3px;
+    }
+  }
+}
+
+.project-card-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 220px;
+}
+
+.project-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.project-icon {
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.project-name {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  letter-spacing: -0.01em;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.featured-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.25rem 0.5rem;
+  background: linear-gradient(135deg, var(--accent-pink), var(--accent-purple));
+  color: white;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.project-description {
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0 0 1rem;
+  flex: 1;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.project-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.project-tag {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  background: var(--bg-accent);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  transition: all var(--transition-fast);
+
+  .project-card:hover & {
+    border-color: var(--border-active);
+  }
+}
+
+.project-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.project-language {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.language-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.language-name {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+}
+
+.project-link-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  transition: color var(--transition-fast);
+
+  svg {
+    transition: transform var(--transition-fast);
+  }
+}
+
+// GitHub CTA Section
+.github-cta {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: var(--bg-card);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border-color);
+  margin-top: 2rem;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(
+      90deg,
+      var(--accent-pink) 0%,
+      var(--accent-cyan) 25%,
+      var(--primary-color) 50%,
+      var(--accent-blue) 75%,
+      var(--accent-pink) 100%
+    );
+    animation: gradient-shift 3s ease-in-out infinite;
+  }
+
+  @keyframes gradient-shift {
+    0%,
+    100% {
+      opacity: 0.7;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  p {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+    margin: 0 0 1.5rem;
+    font-style: italic;
+  }
+}
+
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.5rem;
+  background: var(--primary-color);
+  color: white;
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  font-family:
+    'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+    monospace;
+  text-transform: lowercase;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all var(--transition-normal);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 255, 255, 0.2),
+      transparent
+    );
+    transition: left 0.5s;
+  }
+
+  &:hover {
+    background: var(--primary-dark);
+    transform: translateY(-2px);
+    box-shadow:
+      0 0 20px rgba(0, 255, 136, 0.4),
+      var(--shadow-md);
+
+    &::before {
+      left: 100%;
+    }
+  }
+
+  svg {
+    flex-shrink: 0;
+  }
+}
+
+// Glow animation (shared with other pages)
+@keyframes glow {
+  from {
+    text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+  }
+  to {
+    text-shadow:
+      0 0 30px rgba(0, 255, 136, 0.6),
+      0 0 40px rgba(0, 255, 136, 0.3);
+  }
+}
+
+// Responsive Design
+@media (max-width: 768px) {
+  .projects-page {
+    padding: 0 1rem 2rem;
+  }
+
+  .projects-header {
+    padding: calc(var(--header-height) + 0.5rem) 0 1.5rem;
+    margin-bottom: 2rem;
+
+    h1 {
+      font-size: 2rem;
+    }
+
+    p {
+      font-size: 1rem;
+    }
+  }
+
+  .projects-grid {
+    grid-template-columns: 1fr;
+
+    &.featured-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .project-card-content {
+    padding: 1.25rem;
+    min-height: auto;
+  }
+
+  .project-description {
+    -webkit-line-clamp: 4;
+  }
+
+  .github-cta {
+    padding: 2rem 1.5rem;
+  }
+
+  .github-link {
+    width: 100%;
+    justify-content: center;
+    max-width: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .project-header {
+    flex-wrap: wrap;
+  }
+
+  .featured-badge {
+    order: 3;
+    width: auto;
+  }
+
+  .project-footer {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: flex-start;
+  }
+}
+
+// Light mode specific enhancements
+[data-theme='light'] {
+  .projects-header {
+    h1 {
+      color: white;
+      text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+
+      &::after {
+        background: var(--accent-color);
+        box-shadow: 0 0 10px rgba(255, 0, 128, 0.5);
+      }
+    }
+
+    p {
+      color: rgba(255, 255, 255, 0.8);
+    }
+  }
+
+  .project-card {
+    background: var(--bg-card);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+
+    &:hover {
+      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.12);
+    }
+  }
+
+  .project-tag {
+    background: var(--bg-hover);
+    border-color: var(--border-color);
+  }
+
+  .github-cta {
+    background: var(--bg-card);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  }
+
+  .github-link {
+    background: var(--primary-color);
+
+    &:hover {
+      background: var(--primary-dark);
+      box-shadow: 0 4px 12px rgba(0, 168, 84, 0.3);
+    }
+  }
+}


### PR DESCRIPTION
- Create projects.ts config with typed GitHubProject interface
- Add projects page with featured/regular project sections
- Design project cards with language, tags, and description
- Add projects to navigation bar between blog and cv
- Style with retro-futuristic theme matching site design