### PR TITLE
Chat export dialog and per-message copy button

### DIFF
--- a/src/__tests__/unit/chat/ExportChatDialog.test.tsx
+++ b/src/__tests__/unit/chat/ExportChatDialog.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import ExportChatDialog, {
+  formatMessagesToMarkdown,
+} from '../../../components/chat/ExportChatDialog';
+import { ChatMessage } from '../../../types/chat';
+
+const messages: ChatMessage[] = [
+  {
+    id: '1',
+    role: 'user',
+    content: "what's Alex's current role?",
+    timestamp: new Date('2026-01-01T12:00:00'),
+  },
+  {
+    id: '2',
+    role: 'assistant',
+    content: 'Alex is a Senior AI Engineer at Perch Insights.',
+    thinking: 'The CV says Perch Insights.',
+    timestamp: new Date('2026-01-01T12:00:05'),
+  },
+];
+
+describe('formatMessagesToMarkdown', () => {
+  it('formats roles and content without thinking by default', () => {
+    const md = formatMessagesToMarkdown(messages, false);
+    expect(md).toContain('## User');
+    expect(md).toContain("what's Alex's current role?");
+    expect(md).toContain('## Assistant');
+    expect(md).toContain('Senior AI Engineer at Perch Insights');
+    expect(md).not.toContain('### Thinking');
+    expect(md).toContain('---');
+  });
+
+  it('includes thinking blocks when requested', () => {
+    const md = formatMessagesToMarkdown(messages, true);
+    expect(md).toContain('### Thinking');
+    expect(md).toContain('The CV says Perch Insights.');
+    expect(md).toContain('### Response');
+  });
+
+  it('returns empty string for no messages', () => {
+    expect(formatMessagesToMarkdown([], false)).toBe('');
+  });
+});
+
+describe('ExportChatDialog', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <ExportChatDialog
+        isOpen={false}
+        onCancel={jest.fn()}
+        messages={messages}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows message count and thinking checkbox when open', () => {
+    render(
+      <ExportChatDialog
+        isOpen={true}
+        onCancel={jest.fn()}
+        messages={messages}
+      />
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('include thinking blocks')).toBeInTheDocument();
+  });
+
+  it('calls onCancel when cancel is clicked', () => {
+    const onCancel = jest.fn();
+    render(
+      <ExportChatDialog isOpen={true} onCancel={onCancel} messages={messages} />
+    );
+    fireEvent.click(screen.getByText('cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -99,11 +99,22 @@ interface MessageItemProps {
 
 const MessageItem = React.memo<MessageItemProps>(
   ({ message, isLastMessage, isGenerating, isExpanded, onToggleThinking }) => {
+    const [copied, setCopied] = useState(false);
     const hasThinking = !!(message.thinking && message.thinking.length > 0);
     const displayContent = message.content;
     const thinkingContent = message.thinking || '';
     const isThinkingIncomplete =
       isLastMessage && isGenerating && hasThinking && !message.content;
+
+    const copyToClipboard = async () => {
+      try {
+        await navigator.clipboard.writeText(displayContent);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error('Failed to copy message:', err);
+      }
+    };
 
     return (
       <div className={`chat-message ${message.role}`}>
@@ -129,7 +140,53 @@ const MessageItem = React.memo<MessageItemProps>(
             ))}
 
           <div className="message-timestamp">
-            {formatTime(message.timestamp)}
+            <span className="timestamp-text">
+              {formatTime(message.timestamp)}
+            </span>
+            {displayContent && (
+              <button
+                className="copy-button"
+                onClick={copyToClipboard}
+                aria-label={copied ? 'Copied!' : 'Copy message'}
+                title={copied ? 'Copied!' : 'Copy message'}
+              >
+                {copied ? (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <polyline points="20,6 9,17 4,12"></polyline>
+                  </svg>
+                ) : (
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <rect
+                      x="9"
+                      y="9"
+                      width="13"
+                      height="13"
+                      rx="2"
+                      ry="2"
+                    ></rect>
+                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                  </svg>
+                )}
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/chat/ChatModal.tsx
+++ b/src/components/chat/ChatModal.tsx
@@ -5,6 +5,7 @@ import ChatErrorBoundary from './ChatErrorBoundary';
 import ChatInput from './ChatInput';
 import ChatMessage from './ChatMessage';
 import ClearConfirmDialog from './ClearConfirmDialog';
+import ExportChatDialog from './ExportChatDialog';
 import Progress from './Progress';
 import SamplePrompts from './SamplePrompts';
 import ThinkingToggle from './ThinkingToggle';
@@ -34,6 +35,7 @@ const ChatModal: React.FC = () => {
     retryModelLoad,
   } = useChat();
   const [showClearConfirm, setShowClearConfirm] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
   const [promptValue, setPromptValue] = useState<string | undefined>(undefined);
   const [skipConfirm, setSkipConfirm] = useState(() => {
     if (typeof window !== 'undefined') {
@@ -134,6 +136,32 @@ const ChatModal: React.FC = () => {
               })}
             </select>
           </div>
+          {messages.length > 0 && (
+            <button
+              className="chat-export-button"
+              onClick={() => setShowExportDialog(true)}
+              disabled={isGenerating}
+              aria-label="Export chat as markdown"
+              title="Export chat as markdown"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                <polyline points="14,2 14,8 20,8" />
+                <line x1="16" y1="13" x2="8" y2="13" />
+                <line x1="16" y1="17" x2="8" y2="17" />
+                <polyline points="10,9 9,9 8,9" />
+              </svg>
+            </button>
+          )}
           {messages.length > 0 && (
             <button
               className="chat-clear-button"
@@ -337,6 +365,12 @@ const ChatModal: React.FC = () => {
           <kbd>C</kbd> chat • <kbd>Enter</kbd> send
         </div>
       </div>
+
+      <ExportChatDialog
+        isOpen={showExportDialog}
+        onCancel={() => setShowExportDialog(false)}
+        messages={messages}
+      />
 
       <ClearConfirmDialog
         isOpen={showClearConfirm}

--- a/src/components/chat/ExportChatDialog.tsx
+++ b/src/components/chat/ExportChatDialog.tsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import { ChatMessage } from '../../types/chat';
+
+interface ExportChatDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  messages: ChatMessage[];
+}
+
+/**
+ * Formats the conversation as markdown. Thinking blocks live in
+ * message.thinking (the worker strips <think> tags from content), so they
+ * are only included when requested.
+ */
+export const formatMessagesToMarkdown = (
+  messages: ChatMessage[],
+  includeThinking: boolean
+): string => {
+  if (!messages || messages.length === 0) return '';
+
+  return messages
+    .map(message => {
+      const parts: string[] = [
+        `## ${message.role === 'user' ? 'User' : 'Assistant'}`,
+      ];
+
+      if (includeThinking && message.role === 'assistant' && message.thinking) {
+        parts.push(
+          `### Thinking\n\n${message.thinking.trim()}\n\n### Response`
+        );
+      }
+
+      parts.push((message.content || '').trim());
+      return parts.join('\n\n');
+    })
+    .join('\n\n---\n\n');
+};
+
+const ExportChatDialog: React.FC<ExportChatDialogProps> = ({
+  isOpen,
+  onCancel,
+  messages,
+}) => {
+  const [includeThinking, setIncludeThinking] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  if (!isOpen) return null;
+
+  const hasThinking = messages.some(m => m.thinking);
+
+  const handleCopyToClipboard = async () => {
+    setIsExporting(true);
+    const markdown = formatMessagesToMarkdown(messages, includeThinking);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      onCancel();
+    } catch (err) {
+      console.error('Failed to copy to clipboard:', err);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleDownloadFile = () => {
+    setIsExporting(true);
+    try {
+      const markdown = formatMessagesToMarkdown(messages, includeThinking);
+      const blob = new Blob([markdown], { type: 'text/markdown' });
+      const url = URL.createObjectURL(blob);
+
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `chat-export-${new Date().toISOString().split('T')[0]}.md`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      URL.revokeObjectURL(url);
+      onCancel();
+    } catch (err) {
+      console.error('Failed to download file:', err);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (!isExporting) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="export-chat-overlay" onClick={handleCancel}>
+      <div
+        className="export-chat-dialog"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="export-dialog-title"
+      >
+        <div className="export-chat-header">
+          <h3 id="export-dialog-title">export chat</h3>
+        </div>
+
+        <div className="export-chat-content">
+          <p className="export-message">
+            export <strong>{messages.length}</strong> message
+            {messages.length !== 1 ? 's' : ''} as markdown
+          </p>
+
+          {hasThinking && (
+            <label className="thinking-toggle-checkbox">
+              <input
+                type="checkbox"
+                checked={includeThinking}
+                onChange={e => setIncludeThinking(e.target.checked)}
+                disabled={isExporting}
+              />
+              <span className="checkbox-label">include thinking blocks</span>
+            </label>
+          )}
+        </div>
+
+        <div className="export-chat-actions">
+          <button
+            className="export-cancel-button"
+            onClick={handleCancel}
+            disabled={isExporting}
+          >
+            cancel
+          </button>
+          <button
+            className="export-copy-button"
+            onClick={handleCopyToClipboard}
+            disabled={isExporting || messages.length === 0}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+            </svg>
+            copy
+          </button>
+          <button
+            className="export-download-button"
+            onClick={handleDownloadFile}
+            disabled={isExporting || messages.length === 0}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7,10 12,15 17,10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            download
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportChatDialog;

--- a/src/styles/chat.scss
+++ b/src/styles/chat.scss
@@ -329,6 +329,7 @@
       }
     }
 
+    .chat-export-button,
     .chat-clear-button,
     .chat-close-button {
       background: transparent;
@@ -675,6 +676,7 @@
       }
     }
 
+    .chat-export-button,
     .chat-clear-button,
     .chat-close-button {
       background: transparent;
@@ -2320,6 +2322,182 @@
 
       &:last-child {
         margin-bottom: 0;
+      }
+    }
+  }
+}
+
+// Per-message copy button (revealed on message hover)
+.chat-message {
+  .message-timestamp {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+
+    .timestamp-text {
+      flex: 1;
+    }
+
+    .copy-button {
+      background: transparent;
+      border: none;
+      color: var(--text-primary);
+      cursor: pointer;
+      padding: 0.25rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--radius-sm);
+      transition: all var(--transition-fast);
+      opacity: 0;
+      transform: translateY(2px);
+
+      svg {
+        flex-shrink: 0;
+      }
+
+      &:hover {
+        color: var(--primary-color);
+        background: var(--bg-hover);
+        transform: translateY(0);
+      }
+
+      &:active {
+        transform: scale(0.95);
+      }
+
+      &[title='Copied!'] {
+        color: var(--primary-color);
+        opacity: 1;
+      }
+    }
+  }
+
+  &:hover .message-timestamp .copy-button,
+  .message-timestamp .copy-button:focus-visible {
+    opacity: 0.7;
+    transform: translateY(0);
+  }
+}
+
+// Export chat dialog
+.export-chat-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: var(--bg-primary);
+  backdrop-filter: blur(5px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+.export-chat-dialog {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  width: min(420px, calc(100vw - 2rem));
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .export-chat-header h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 1rem;
+    font-weight: 600;
+  }
+
+  .export-chat-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    .export-message {
+      margin: 0;
+      color: var(--text-secondary);
+      font-size: 0.875rem;
+
+      strong {
+        color: var(--text-primary);
+      }
+    }
+
+    .thinking-toggle-checkbox {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      cursor: pointer;
+      user-select: none;
+
+      input[type='checkbox'] {
+        width: 16px;
+        height: 16px;
+        accent-color: var(--accent-purple);
+        cursor: pointer;
+      }
+
+      .checkbox-label {
+        color: var(--text-secondary);
+        font-size: 0.8125rem;
+      }
+
+      &:hover .checkbox-label {
+        color: var(--text-primary);
+      }
+    }
+  }
+
+  .export-chat-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+
+    button {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-family: inherit;
+      font-size: 0.8125rem;
+      border-radius: 8px;
+      padding: 0.5rem 0.875rem;
+      cursor: pointer;
+      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    }
+
+    .export-cancel-button {
+      background: transparent;
+      border: 1px solid var(--border-color);
+      color: var(--text-secondary);
+
+      &:hover:not(:disabled) {
+        background: var(--bg-hover);
+        color: var(--text-primary);
+      }
+    }
+
+    .export-copy-button,
+    .export-download-button {
+      background: transparent;
+      border: 1px solid var(--accent-purple);
+      color: var(--text-primary);
+
+      &:hover:not(:disabled) {
+        background: var(--bg-accent);
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-md);
       }
     }
   }


### PR DESCRIPTION
Reimplements the export/copy UX from the retired `feat/chat-ux` branch (closed as #19) on the current chat architecture.

## What's included
- **Export dialog**: export the whole conversation as markdown — copy to clipboard or download as `.md`. When any message has thinking content, an opt-in checkbox includes the thinking blocks (thinking now lives in `message.thinking`, not `<think>` tags, per the new worker architecture).
- **Export button** in the chat header, shown once there are messages, disabled while generating.
- **Copy button** on every message, revealed on hover (also focus-visible for keyboard users), with a 2s checkmark confirmation.
- Unit tests for the markdown formatter and dialog behavior.

## Verification
- 519 jest tests pass, tsc clean, production build green
- Verified end-to-end with Playwright on real WebGPU: hover-copy puts the exact answer text on the clipboard; export-copy yields well-formed markdown (`## User` / `## Assistant` sections with separators); dialog closes on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRapsYqPiwiid996dX1oQ2