### PR TITLE
fix: serve at custom domain root (drop /alexnodeland pathPrefix, add CNAME)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,8 +77,6 @@ jobs:
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
 
       - name: Build with Gatsby
-        env:
-          PREFIX_PATHS: 'true'
         run: ${{ steps.detect-package-manager.outputs.manager }} run build
 
       - name: Upload artifact

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -5,12 +5,12 @@ import { siteConfig } from './src/config/site';
  * @type {import('gatsby').GatsbyConfig}
  */
 const config: import('gatsby').GatsbyConfig = {
-  pathPrefix: `/alexnodeland`,
+  pathPrefix: `/`,
   siteMetadata: {
     title: siteConfig.siteName,
     description: siteConfig.description,
     author: siteConfig.author,
-    siteUrl: `https://alexnodeland.github.io/alexnodeland`,
+    siteUrl: `https://alexnodeland.com`,
   },
   plugins: [
     `gatsby-plugin-typescript`,

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -19,7 +19,7 @@ const SEO: React.FC<SEOProps> = ({
   const fullTitle =
     title === siteConfig.siteName ? title : `${title} | ${siteConfig.siteName}`;
 
-  // Icon paths must respect the deploy pathPrefix (/alexnodeland).
+  // Icon paths must respect the deploy pathPrefix.
   const iconHref = withPrefix('/images/icon.png');
 
   // Social crawlers require ABSOLUTE image URLs. Pass through anything already

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+alexnodeland.com


### PR DESCRIPTION
## Problem
Moved from the GitHub project-page URL (`alexnodeland.github.io/alexnodeland`) to the custom domain **alexnodeland.com**, served at the root. The build still applied `pathPrefix: '/alexnodeland'`, so every asset (backgrounds), JS bundle, and page route was emitted under `/alexnodeland/...` and 404'd at the domain root — breaking backgrounds, the settings panel (React never hydrated), and all non-home pages.

## Changes
- `gatsby-config.ts`: `pathPrefix` `'/alexnodeland'` → `'/'`; `siteUrl` → `https://alexnodeland.com`
- `.github/workflows/deploy.yml`: remove `PREFIX_PATHS=true` so CI no longer forces the prefix
- `static/CNAME`: bake the custom domain into every deploy artifact (persists custom domain across deploys)
- `seo.tsx`: drop stale prefix reference in comment

## Verification
Local `gatsby build`:
- ✅ Zero `/alexnodeland/` paths remain in built HTML
- ✅ Assets are root-relative (`/styles….css`, `/images/icon.png`)
- ✅ Routes build at root (`/blog/`, `/cv/`, `/projects/`, `/404/`, home)
- ✅ `public/CNAME` = `alexnodeland.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)