### PR TITLE
Rewrite site copy, fix two fake backgrounds, add a one-page resume

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,14 +63,20 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
 
+      # Only .cache is restored, never public. Restoring a previous public/
+      # lets Gatsby keep a stale index.html that references an old
+      # styles.<hash>.css while writing the new stylesheet beside it,
+      # unreferenced — a CSS-only change then deploys with no visible effect
+      # and a green build. Reproduced locally; see the subtitle-halo commit.
+      # .cache holds the expensive work (transforms, image processing) and is
+      # keyed on lockfile + source so it invalidates correctly on its own.
       - name: Restore cache
         uses: actions/cache@v4
         with:
-          path: |
-            public
-            .cache
-          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('public') }}
+          path: .cache
+          key: ${{ runner.os }}-gatsby-build-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**', 'gatsby-*.ts', 'gatsby-*.js') }}
           restore-keys: |
+            ${{ runner.os }}-gatsby-build-${{ hashFiles('package-lock.json') }}-
             ${{ runner.os }}-gatsby-build-
 
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,11 @@ static/*.wasm
 
 # Playwright MCP artifacts and ad-hoc screenshots
 .playwright-mcp/
+
+# Local copies of third-party press articles. Kept on disk as personal
+# reference copies but deliberately not committed — they are someone else's
+# copyrighted work. Regenerate with `just archive-press`. The README stays
+# tracked because it holds the original and Wayback URLs, which is the part
+# worth version-controlling.
+archive/press/*
+!archive/press/README.md

--- a/archive/press/README.md
+++ b/archive/press/README.md
@@ -1,0 +1,47 @@
+# Press archive
+
+Local copies of the external articles linked from `src/content/blog/`, kept
+because several of these publications are small or defunct-adjacent and the
+links are already 7-11 years old. `sbpress.com` in particular is a student
+newspaper with no institutional guarantee of staying up.
+
+Retrieved 2026-07-25. Each item has the original page (`.html`/`.pdf`) and, for
+HTML, a plain-text extraction (`.txt`) so the words survive even if the markup
+or its assets do not.
+
+**Not published, and not committed.** Gatsby only sources `src/pages`,
+`src/content/blog` and `src/images`, so nothing here reaches the built site; and
+`.gitignore` excludes everything in this directory except this README. Both are
+deliberate — these are third-party copyrighted articles, fine to keep as
+personal reference copies, not to republish or redistribute. If you ever want an
+excerpt on the site, quote a paragraph and link out rather than mirroring the
+page.
+
+The files therefore live only on this machine. This README is tracked because
+the table below — original URLs paired with Wayback snapshots — is the part
+worth version-controlling: it is what lets you rebuild the archive anywhere, and
+it survives even if the local copies are lost.
+
+| Article                                                                       | Original                                                                                   | Wayback snapshot                                                                                                                      |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| The Future of Sound (The Stony Brook Press, 2015-11-11)                       | https://sbpress.com/2015/11/the-future-of-sound/                                           | https://web.archive.org/web/20260120052756/https://sbpress.com/2015/11/the-future-of-sound/                                           |
+| Supercomputers For Audio Research (CEWIT Newsletter, 2016-02)                 | https://www.cewit.org/programs/_documents/CEWITNewsletter_FEB2016.pdf                      | https://web.archive.org/web/20230723115756/https://www.cewit.org/programs/_documents/CEWITNewsletter_FEB2016.pdf                      |
+| Optimal Wavelet Bases (CEWIT Newsletter, 2016-11)                             | https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf                      | https://web.archive.org/web/20230723115819/https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf                      |
+| Supercomputing Shouldn't Be Rocket Science (Asian Scientist, 2019-03)         | https://www.asianscientist.com/2019/03/features/supercomputing-shouldnt-be-rocket-science/ | https://web.archive.org/web/20260218032240/https://www.asianscientist.com/2019/03/features/supercomputing-shouldnt-be-rocket-science/ |
+| Singapore Startup Hatches At-Scale HPC Dev Cloud (HPCwire, 2019-04-26)        | https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/                | https://web.archive.org/web/20250722110011/https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/                |
+| Try Before You Buy? Test Driving a Supercomputer System (HPCwire, 2019-10-07) | https://www.hpcwire.com/2019/10/07/try-before-you-buy-test-driving-a-supercomputer-system/ | https://web.archive.org/web/20220124003030/https://www.hpcwire.com/2019/10/07/try-before-you-buy-test-driving-a-supercomputer-system/ |
+
+## Notes
+
+- Both HPCwire pages sit behind Cloudflare and will return an "Attention
+  Required" interstitial for a request with a terse user-agent. The archive
+  script sends a full browser UA, which gets through; if that ever stops
+  working it falls back to the Wayback snapshot automatically.
+- The CEWIT items are whole newsletters, not standalone articles. The relevant
+  pieces are inside the PDFs.
+
+## Re-running
+
+```sh
+just archive-press     # refresh local copies and resubmit to the Wayback Machine
+```

--- a/justfile
+++ b/justfile
@@ -76,3 +76,7 @@ quality:
 # Run all code quality checks with auto-fix
 quality-fix:
     npm run code-quality:fix
+
+# Re-archive the press articles linked from the blog (local copies + Wayback)
+archive-press:
+    ./scripts/archive-press.sh

--- a/scripts/archive-press.sh
+++ b/scripts/archive-press.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Archives the external articles linked from src/content/blog.
+#
+# Two independent safeguards against link rot: a local copy in archive/press
+# (plus a plain-text extraction, so the words outlive the markup), and a fresh
+# Wayback Machine snapshot. Neither is published — see archive/press/README.md.
+#
+# Safe to re-run; existing copies are overwritten only on a successful fetch.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$REPO_ROOT/archive/press"
+UA="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+
+mkdir -p "$OUT_DIR"
+
+# name|url — keep in sync with the table in archive/press/README.md
+ARTICLES=(
+  "2015-11_the-future-of-sound|https://sbpress.com/2015/11/the-future-of-sound/"
+  "2016-02_cewit-newsletter|https://www.cewit.org/programs/_documents/CEWITNewsletter_FEB2016.pdf"
+  "2016-11_cewit-newsletter|https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf"
+  "2019-03_supercomputing-shouldnt-be-rocket-science|https://www.asianscientist.com/2019/03/features/supercomputing-shouldnt-be-rocket-science/"
+  "2019-04_hpcwire-archanan-launch|https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/"
+  "2019-10_hpcwire-test-driving|https://www.hpcwire.com/2019/10/07/try-before-you-buy-test-driving-a-supercomputer-system/"
+)
+
+# Returns the URL of the most recent Wayback snapshot, or empty if none exists.
+wayback_url() {
+  curl -s --max-time 30 "https://archive.org/wayback/available?url=$1" |
+    python3 -c "import sys,json; print(json.load(sys.stdin).get('archived_snapshots',{}).get('closest',{}).get('url',''))" 2>/dev/null
+}
+
+failures=0
+
+for entry in "${ARTICLES[@]}"; do
+  name="${entry%%|*}"
+  url="${entry#*|}"
+  ext=html
+  [[ "$url" == *.pdf ]] && ext=pdf
+  dest="$OUT_DIR/$name.$ext"
+  tmp="$(mktemp)"
+
+  echo "==> $name"
+
+  if curl -sfL --max-time 60 -A "$UA" "$url" -o "$tmp" && [ -s "$tmp" ] &&
+    ! grep -qa "Attention Required! | Cloudflare" "$tmp"; then
+    mv "$tmp" "$dest"
+    echo "    fetched from origin"
+  else
+    # Origin refused us (HPCwire sits behind Cloudflare) — fall back to Wayback.
+    snapshot="$(wayback_url "$url")"
+    if [ -n "$snapshot" ] && curl -sfL --max-time 90 -A "$UA" "$snapshot" -o "$tmp" && [ -s "$tmp" ]; then
+      mv "$tmp" "$dest"
+      echo "    origin blocked; fetched from Wayback"
+    else
+      rm -f "$tmp"
+      echo "    FAILED: origin and Wayback both unavailable"
+      failures=$((failures + 1))
+      continue
+    fi
+  fi
+
+  # Plain-text extraction so the content survives the markup (macOS textutil).
+  if [ "$ext" = html ] && command -v textutil >/dev/null 2>&1; then
+    textutil -convert txt -stdout "$dest" 2>/dev/null |
+      sed '/^[[:space:]]*$/d' >"$OUT_DIR/$name.txt"
+    echo "    extracted $(wc -w <"$OUT_DIR/$name.txt" | tr -d ' ') words"
+  fi
+
+  # Ask the Wayback Machine for a fresh capture. Best-effort: this endpoint is
+  # rate-limited and slow, and a failure here costs us nothing.
+  curl -s -o /dev/null --max-time 60 "https://web.archive.org/save/$url" &&
+    echo "    resubmitted to Wayback" ||
+    echo "    Wayback save skipped (rate-limited or slow)"
+done
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "Done with $failures failure(s). Existing copies were left untouched."
+  exit 1
+fi
+echo "Done. $(ls -1 "$OUT_DIR" | grep -vc README.md) files in archive/press."

--- a/src/__tests__/unit/components/animated-backgrounds/CellularAutomatonBackground.test.tsx
+++ b/src/__tests__/unit/components/animated-backgrounds/CellularAutomatonBackground.test.tsx
@@ -1,32 +1,54 @@
 import { render } from '@testing-library/react';
 import CellularAutomatonBackground from '../../../../components/animated-backgrounds/backgrounds/cellular-automaton/CellularAutomatonBackground';
+import { LIFE_RULES } from '../../../../components/animated-backgrounds/backgrounds/cellular-automaton/config';
+
+const baseSettings: any = {
+  opacity: 0.9,
+  elementSize: 0.02,
+  globalTimeMultiplier: 1,
+  rule: 'conway',
+  cellSize: 24,
+  generationsPerSecond: 3,
+  initialDensity: 0.3,
+  perturbationRate: 0.0005,
+  cellScale: 0.55,
+  connectionLineWidth: 0.06,
+  activityIntensity: 1.2,
+  colors: {
+    primary: [1, 0, 0],
+    secondary: [0, 1, 0],
+    accent: [0, 0, 1],
+    background: [0, 0, 0],
+    grid: [0.5, 0.5, 0.5],
+  },
+};
 
 describe('CellularAutomatonBackground', () => {
   it('mounts and unmounts', () => {
-    const settings: any = {
-      opacity: 0.9,
-      elementSize: 0.02,
-      globalTimeMultiplier: 1,
-      cellSize: 0.2,
-      cellSizeMultiplier: 0.1,
-      evolutionSpeed1: 1,
-      evolutionSpeed2: 1,
-      diagonalEvolutionSpeed: 1,
-      updateAnimationSpeed: 1,
-      waveAmplitude: 0.5,
-      connectionLineWidth: 0.003,
-      diagonalConnectionWeight: 0.5,
-      activityIntensity: 0.7,
-      colors: {
-        primary: [1, 0, 0],
-        secondary: [0, 1, 0],
-        accent: [0, 0, 1],
-        background: [0, 0, 0],
-        grid: [0.5, 0.5, 0.5],
-      },
-    };
     const { unmount } = render(
-      <CellularAutomatonBackground className="bg" settings={settings} />
+      <CellularAutomatonBackground className="bg" settings={baseSettings} />
+    );
+    unmount();
+  });
+
+  it('mounts for every available rule', () => {
+    Object.keys(LIFE_RULES).forEach(rule => {
+      const { unmount } = render(
+        <CellularAutomatonBackground
+          className="bg"
+          settings={{ ...baseSettings, rule }}
+        />
+      );
+      unmount();
+    });
+  });
+
+  it('falls back to Conway for an unknown rule', () => {
+    const { unmount } = render(
+      <CellularAutomatonBackground
+        className="bg"
+        settings={{ ...baseSettings, rule: 'not-a-rule' }}
+      />
     );
     unmount();
   });

--- a/src/__tests__/unit/components/animated-backgrounds/SimpleWaveBackground.test.tsx
+++ b/src/__tests__/unit/components/animated-backgrounds/SimpleWaveBackground.test.tsx
@@ -9,7 +9,12 @@ describe('SimpleWaveBackground', () => {
       globalTimeMultiplier: 1,
       waveFrequency: 2,
       waveAmplitude: 0.5,
-      colors: { primary: [1, 0, 0], secondary: [0, 1, 0], accent: [0, 0, 1] },
+      colors: {
+        primary: [1, 0, 0],
+        secondary: [0, 1, 0],
+        accent: [0, 0, 1],
+        background: [0, 0, 0],
+      },
     };
     const { container, unmount } = render(
       <SimpleWaveBackground className="bg" settings={settings} />

--- a/src/__tests__/unit/components/animated-backgrounds/backgrounds/automaton.test.ts
+++ b/src/__tests__/unit/components/animated-backgrounds/backgrounds/automaton.test.ts
@@ -1,0 +1,160 @@
+import {
+  makeRuleTables,
+  population,
+  stepLife,
+} from '../../../../../components/animated-backgrounds/backgrounds/cellular-automaton/automaton';
+
+const COLS = 8;
+const ROWS = 8;
+
+/** Builds a grid from a picture, '#' meaning alive. */
+const grid = (rows: string[]): Uint8Array => {
+  const g = new Uint8Array(COLS * ROWS);
+  rows.forEach((row, y) => {
+    row.split('').forEach((ch, x) => {
+      g[y * COLS + x] = ch === '#' ? 1 : 0;
+    });
+  });
+  return g;
+};
+
+/** Renders a grid back to a picture for readable assertions. */
+const draw = (g: Uint8Array): string[] =>
+  Array.from({ length: ROWS }, (_, y) =>
+    Array.from({ length: COLS }, (_, x) => (g[y * COLS + x] ? '#' : '.')).join(
+      ''
+    )
+  );
+
+const advance = (start: Uint8Array, rule = 'conway', generations = 1) => {
+  const tables = makeRuleTables(rule);
+  let current = start;
+  for (let i = 0; i < generations; i++) {
+    const next = new Uint8Array(current.length);
+    stepLife(current, next, COLS, ROWS, tables);
+    current = next;
+  }
+  return current;
+};
+
+const BLANK = '........';
+
+describe('stepLife', () => {
+  it('oscillates a blinker with period 2', () => {
+    const horizontal = [
+      BLANK,
+      BLANK,
+      BLANK,
+      '..###...',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ];
+    const vertical = [
+      BLANK,
+      BLANK,
+      '...#....',
+      '...#....',
+      '...#....',
+      BLANK,
+      BLANK,
+      BLANK,
+    ];
+
+    expect(draw(advance(grid(horizontal)))).toEqual(vertical);
+    expect(draw(advance(grid(horizontal), 'conway', 2))).toEqual(horizontal);
+  });
+
+  it('leaves a block still life untouched', () => {
+    const block = [
+      BLANK,
+      '..##....',
+      '..##....',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ];
+    expect(draw(advance(grid(block), 'conway', 4))).toEqual(block);
+  });
+
+  it('translates a glider one cell diagonally every four generations', () => {
+    const glider = grid([
+      '.#......',
+      '..#.....',
+      '###.....',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ]);
+    const moved = grid([
+      BLANK,
+      '..#.....',
+      '...#....',
+      '.###....',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ]);
+    expect(draw(advance(glider, 'conway', 4))).toEqual(draw(moved));
+  });
+
+  it('wraps around the torus rather than clipping at the edge', () => {
+    // A blinker straddling the right edge stays a blinker.
+    const straddling = grid([
+      BLANK,
+      BLANK,
+      BLANK,
+      '#.....##',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ]);
+    expect(population(advance(straddling))).toBe(3);
+  });
+
+  it('kills every cell under Seeds, which has no survival counts', () => {
+    const soup = grid([
+      '.##.....',
+      '.##.....',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ]);
+    const after = advance(soup, 'seeds');
+    // The original block cannot survive (S is empty); only births remain.
+    expect(after[1 * COLS + 1]).toBe(0);
+    expect(after[1 * COLS + 2]).toBe(0);
+  });
+
+  it('falls back to Conway for an unknown rule id', () => {
+    const blinker = grid([
+      BLANK,
+      BLANK,
+      BLANK,
+      '..###...',
+      BLANK,
+      BLANK,
+      BLANK,
+      BLANK,
+    ]);
+    expect(draw(advance(blinker, 'nonsense'))).toEqual(
+      draw(advance(blinker, 'conway'))
+    );
+  });
+});
+
+describe('population', () => {
+  it('counts live cells', () => {
+    expect(population(grid(['##......', ...Array(7).fill(BLANK)]))).toBe(2);
+  });
+});

--- a/src/components/animated-backgrounds/SettingsPanel.tsx
+++ b/src/components/animated-backgrounds/SettingsPanel.tsx
@@ -238,6 +238,22 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
   };
 
   // Render setting input based on type
+  // The settings list scrolls, so a tooltip anchored above its icon is clipped
+  // for any control near the top of the viewport. Measure the room actually
+  // available and flip it below when there isn't enough.
+  const positionTooltip = useCallback(
+    (event: React.SyntheticEvent<HTMLSpanElement>) => {
+      const help = event.currentTarget;
+      const tooltip = help.querySelector<HTMLElement>('.setting-tooltip');
+      const scroller = help.closest('.settings-content');
+      if (!tooltip || !scroller) return;
+      const roomAbove =
+        help.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+      help.classList.toggle('flip', roomAbove < tooltip.offsetHeight + 8);
+    },
+    []
+  );
+
   const renderSettingInput = (setting: SettingsSchema) => {
     const value = getNestedValue(settings, setting.key);
 
@@ -467,6 +483,21 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                       <div key={setting.key} className="setting-row">
                         <label className="setting-label">
                           {setting.label?.toLowerCase?.() || ''}
+                          {setting.description && (
+                            <span
+                              className="setting-help"
+                              tabIndex={0}
+                              role="note"
+                              aria-label={setting.description}
+                              onMouseEnter={positionTooltip}
+                              onFocus={positionTooltip}
+                            >
+                              ?
+                              <span className="setting-tooltip" role="tooltip">
+                                {setting.description}
+                              </span>
+                            </span>
+                          )}
                         </label>
                         {renderSettingInput(setting)}
                       </div>
@@ -522,6 +553,21 @@ const SettingsPanel: React.FC<SettingsPanelProps> = ({
                       <div key={setting.key} className="setting-row">
                         <label className="setting-label">
                           {setting.label?.toLowerCase?.() || ''}
+                          {setting.description && (
+                            <span
+                              className="setting-help"
+                              tabIndex={0}
+                              role="note"
+                              aria-label={setting.description}
+                              onMouseEnter={positionTooltip}
+                              onFocus={positionTooltip}
+                            >
+                              ?
+                              <span className="setting-tooltip" role="tooltip">
+                                {setting.description}
+                              </span>
+                            </span>
+                          )}
                         </label>
                         {renderSettingInput(setting)}
                       </div>

--- a/src/components/animated-backgrounds/backgrounds/cellular-automaton/CellularAutomatonBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/cellular-automaton/CellularAutomatonBackground.tsx
@@ -1,36 +1,147 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import { AnimatedBackgroundProps } from '../../core/types';
+import { makeRuleTables, population, stepLife } from './automaton';
 import { CellularAutomatonSettings } from './config';
 
+// Keep the grid bounded regardless of viewport or cell size.
+const MAX_CELLS = 40000;
+
+// Generations of unchanged population before the grid is treated as stalled.
+const STALL_GENERATIONS = 24;
+
+/**
+ * Renders a Life-like cellular automaton.
+ *
+ * The simulation is a genuine state buffer: `current` holds this generation,
+ * `next` is computed from it by counting each cell's eight neighbors on a
+ * wrapping torus and applying the birth/survival rule. The result is uploaded
+ * to a DataTexture each generation and the shader only draws it — the shader
+ * never invents state.
+ *
+ * Texture channels per cell: R = alive now, G = alive last generation,
+ * B = age (generations survived, saturating), A = unused.
+ */
 const CellularAutomatonBackground: React.FC<
   AnimatedBackgroundProps<CellularAutomatonSettings>
 > = ({ className, settings }) => {
   const containerRef = useRef<HTMLDivElement>(null);
-  const sceneRef = useRef<THREE.Scene | null>(null);
-  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
-  const animationFrameRef = useRef<number | null>(null);
+  const materialRef = useRef<THREE.ShaderMaterial | null>(null);
+
+  // Cosmetic settings are pushed straight to uniforms so that changing a color
+  // does not restart the simulation.
+  const { colors, connectionLineWidth, cellScale, activityIntensity, opacity } =
+    settings;
+
+  // Structural settings that require rebuilding the grid.
+  const { rule, cellSize, generationsPerSecond, initialDensity } = settings;
+  const perturbationRate = settings.perturbationRate;
+  const perturbationRef = useRef(perturbationRate);
+  perturbationRef.current = perturbationRate;
 
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    // Scene setup
     const scene = new THREE.Scene();
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
-
     const renderer = new THREE.WebGLRenderer({ alpha: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    const dpr = Math.min(window.devicePixelRatio, 2);
-    renderer.setPixelRatio(dpr);
-
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     container.appendChild(renderer.domElement);
 
-    // Store references
-    sceneRef.current = scene;
-    rendererRef.current = renderer;
+    const tables = makeRuleTables(rule);
 
-    // Vertex shader for the cellular automaton
+    let cols = 0;
+    let rows = 0;
+    let current = new Uint8Array(0);
+    let next = new Uint8Array(0);
+    let age = new Uint8Array(0);
+    let previous = new Uint8Array(0);
+    let texture: THREE.DataTexture | null = null;
+    let pixels = new Uint8Array(0);
+
+    /** Fills the grid with random soup at the configured density. */
+    const seed = () => {
+      for (let i = 0; i < current.length; i++) {
+        current[i] = Math.random() < initialDensity ? 1 : 0;
+        age[i] = current[i];
+      }
+      previous.set(current);
+    };
+
+    /** (Re)builds the grid and its texture for the current viewport. */
+    const buildGrid = () => {
+      const px = Math.max(4, cellSize);
+      let c = Math.max(8, Math.ceil(window.innerWidth / px));
+      let r = Math.max(8, Math.ceil(window.innerHeight / px));
+
+      // Preserve aspect while staying under the cell budget.
+      if (c * r > MAX_CELLS) {
+        const scale = Math.sqrt(MAX_CELLS / (c * r));
+        c = Math.max(8, Math.floor(c * scale));
+        r = Math.max(8, Math.floor(r * scale));
+      }
+
+      cols = c;
+      rows = r;
+      const size = cols * rows;
+      current = new Uint8Array(size);
+      next = new Uint8Array(size);
+      age = new Uint8Array(size);
+      previous = new Uint8Array(size);
+      pixels = new Uint8Array(size * 4);
+      seed();
+
+      texture?.dispose();
+      texture = new THREE.DataTexture(
+        pixels,
+        cols,
+        rows,
+        THREE.RGBAFormat,
+        THREE.UnsignedByteType
+      );
+      texture.minFilter = THREE.NearestFilter;
+      texture.magFilter = THREE.NearestFilter;
+      texture.needsUpdate = true;
+      return texture;
+    };
+
+    /** Advances the automaton exactly one generation. */
+    const step = () => {
+      stepLife(current, next, cols, rows, tables);
+
+      // Random soup under most rules settles into still lifes and oscillators.
+      // A small perturbation keeps the background moving; set the rate to zero
+      // to let it stall honestly.
+      const rate = perturbationRef.current;
+      if (rate > 0) {
+        const flips = Math.floor(next.length * rate);
+        for (let i = 0; i < flips; i++) {
+          next[Math.floor(Math.random() * next.length)] = 1;
+        }
+      }
+
+      previous.set(current);
+      for (let i = 0; i < next.length; i++) {
+        // Age saturates at 255 so long-lived structures stop shifting color.
+        age[i] = next[i] === 1 ? Math.min(255, age[i] + 1) : 0;
+        current[i] = next[i];
+      }
+    };
+
+    /** Copies simulation state into the texture the shader samples. */
+    const uploadState = () => {
+      for (let i = 0; i < current.length; i++) {
+        const o = i * 4;
+        pixels[o] = current[i] * 255;
+        pixels[o + 1] = previous[i] * 255;
+        pixels[o + 2] = Math.min(255, age[i] * 12);
+        pixels[o + 3] = 255;
+      }
+      if (texture) texture.needsUpdate = true;
+    };
+
     const vertexShader = `
       varying vec2 vUv;
       void main() {
@@ -39,302 +150,201 @@ const CellularAutomatonBackground: React.FC<
       }
     `;
 
-    // Fragment shader for cellular automaton simulation
+    // The shader is a pure renderer: it samples cell state and draws it. All
+    // evolution happens on the CPU in step().
     const fragmentShader = `
-      uniform float uTime;
-      uniform vec2 uResolution;
-
-      // Configurable parameters
-      uniform float uCellSize;
-      uniform float uCellBaseSize;
-      uniform float uCellSizeMultiplier;
-      uniform float uGlobalTimeMultiplier;
-      uniform float uEvolutionSpeed1;
-      uniform float uEvolutionSpeed2;
-      uniform float uDiagonalEvolutionSpeed;
-      uniform float uUpdateAnimationSpeed;
-      uniform float uWaveAmplitude;
+      uniform sampler2D uState;
+      uniform vec2 uGrid;
+      uniform float uStepProgress;
+      uniform float uCellScale;
+      uniform float uLinkWidth;
+      uniform float uActivityIntensity;
       uniform vec3 uColorPrimary;
       uniform vec3 uColorSecondary;
       uniform vec3 uColorAccent;
       uniform vec3 uColorBackground;
       uniform vec3 uColorGrid;
-      uniform float uConnectionLineWidth;
-      uniform float uDiagonalConnectionWeight;
-      uniform float uActivityIntensity;
 
       varying vec2 vUv;
 
-      float hash(vec2 p) {
-        return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+      // Alive-ness of a cell, eased between the previous and current
+      // generation so births fade in and deaths fade out.
+      float cellAlpha(vec2 cell) {
+        vec2 uv = (cell + 0.5) / uGrid;
+        vec4 s = texture2D(uState, uv);
+        return mix(s.g, s.r, uStepProgress);
       }
 
-      // Cellular automaton state calculation - Enhanced for concentrated growth communities
-      float getCellState(vec2 pos, float t) {
-        float totalState = 0.0;
-
-        // Create multiple growth centers that slowly evolve
-        vec2 growthCenters[5];
-        growthCenters[0] = vec2(sin(t * 0.15) * 0.8, cos(t * 0.12) * 0.6);
-        growthCenters[1] = vec2(cos(t * 0.18) * 0.7, sin(t * 0.14) * 0.8);
-        growthCenters[2] = vec2(sin(t * 0.11) * 0.9, cos(t * 0.16) * 0.5);
-        growthCenters[3] = vec2(cos(t * 0.13) * 0.6, sin(t * 0.17) * 0.9);
-        growthCenters[4] = vec2(sin(t * 0.19) * 0.5, cos(t * 0.21) * 0.7);
-
-        // Each growth center creates expanding communities
-        for (int i = 0; i < 5; i++) {
-          float communityAge = t - float(i) * 2.0; // Staggered community birth times
-          if (communityAge > 0.0) {
-            vec2 center = growthCenters[i];
-            float distToCenter = length(pos - center);
-
-            // Slow expanding growth with concentrated core
-            float growthRadius = communityAge * 0.3; // Very slow expansion
-            float communityCore = exp(-distToCenter * 8.0); // Strong concentrated center
-
-            // Cellular growth rings that expand slowly
-            float growthRings = sin(distToCenter * 25.0 - communityAge * uEvolutionSpeed1) *
-                               exp(-max(0.0, distToCenter - growthRadius) * 4.0);
-
-            // Community strength based on age and concentration
-            float communityStrength = exp(-communityAge * 0.1) * // Communities fade with age
-                                    (0.4 + 0.6 * communityCore); // Stronger at center
-
-            totalState += growthRings * communityStrength * (0.8 + float(i) * 0.1);
-          }
-        }
-
-        // Slow-moving wave patterns that create substrate for growth
-        float substrate1 = sin(pos.x * 12.0 - t * uEvolutionSpeed2) *
-                          sin(pos.y * 8.0 - t * uEvolutionSpeed1 * 0.8) * 0.3;
-        float substrate2 = sin((pos.x + pos.y) * 10.0 - t * uDiagonalEvolutionSpeed) *
-                          sin((pos.x - pos.y) * 14.0 + t * uEvolutionSpeed2 * 0.7) * 0.25;
-
-        totalState += (substrate1 + substrate2) * uWaveAmplitude * 0.7;
-
-        // Occasional sporadic growth bursts at random locations
-        float sporadicTime = floor(t * 0.2); // Change every 5 seconds
-        vec2 sporadicPos = vec2(hash(vec2(sporadicTime, 1.0)) * 2.0 - 1.0,
-                               hash(vec2(sporadicTime, 2.0)) * 2.0 - 1.0);
-        float sporadicDist = length(pos - sporadicPos);
-        float sporadicBurst = sin(sporadicDist * 30.0 - (t - sporadicTime * 5.0) * 8.0) *
-                            exp(-sporadicDist * 6.0) *
-                            exp(-max(0.0, t - sporadicTime * 5.0) * 2.0);
-
-        totalState += sporadicBurst * 0.4;
-
-        return totalState;
+      float cellAge(vec2 cell) {
+        vec2 uv = (cell + 0.5) / uGrid;
+        return texture2D(uState, uv).b;
       }
 
-      vec3 getAutomatonColor(float state) {
-        // Color mapping using standardized colors
-        if (state < 0.0) {
-          return mix(uColorSecondary, uColorBackground, (state + 1.0));
-        } else if (state < 0.5) {
-          return mix(uColorBackground, uColorPrimary, state * 2.0);
-        } else {
-          return mix(uColorPrimary, uColorAccent, (state - 0.5) * 2.0);
-        }
+      // Distance from p to the segment ab, used to draw neighbor links.
+      float segmentDist(vec2 p, vec2 a, vec2 b) {
+        vec2 pa = p - a;
+        vec2 ba = b - a;
+        float h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
+        return length(pa - ba * h);
       }
 
       void main() {
-        vec2 uv = (gl_FragCoord.xy * 2.0 - uResolution.xy) / uResolution.y;
-        vec3 finalColor = vec3(0.0);
-        float adjustedTime = uTime * uGlobalTimeMultiplier;
+        vec2 gridPos = vUv * uGrid;
+        vec2 cell = floor(gridPos);
+        vec2 local = fract(gridPos) - 0.5;
 
-        // Cellular grid parameters
-        vec2 cellPos = floor(uv / uCellSize);
-        vec2 localUv = fract(uv / uCellSize) - 0.5;
-        vec2 worldPos = cellPos * uCellSize;
+        float alpha = cellAlpha(cell);
+        float age = cellAge(cell);
 
-        // Calculate cellular state at this grid position
-        float cellState = getCellState(worldPos, adjustedTime);
+        // Young cells read as the newborn color and mature toward primary,
+        // with the longest-lived structures tinted by the accent color.
+        vec3 cellColor = mix(uColorSecondary, uColorPrimary, smoothstep(0.0, 0.25, age));
+        cellColor = mix(cellColor, uColorAccent, smoothstep(0.5, 1.0, age));
 
-        // Draw cell (alive/dead state visualization)
-        float cellDistance = length(localUv);
-        float cellSize = uCellBaseSize + abs(cellState) * uCellSizeMultiplier;
-        float cellBrightness = smoothstep(cellSize + 0.01, cellSize - 0.01, cellDistance);
+        // Soft square for the cell body. ('half' is reserved in GLSL.)
+        float halfSize = max(0.05, uCellScale * 0.5);
+        vec2 d = abs(local) - vec2(halfSize);
+        float sdf = length(max(d, 0.0)) + min(max(d.x, d.y), 0.0);
+        float body = 1.0 - smoothstep(0.0, 0.08, sdf);
 
-        vec3 cellColor = getAutomatonColor(cellState);
-        finalColor += cellColor * cellBrightness * (2.0 + abs(cellState) * 3.0);
+        vec3 color = uColorBackground;
+        float intensity = body * alpha;
 
-        // Draw neighbor connections (cellular automaton rules visualization)
-        vec2 neighborOffsets[4];
-        neighborOffsets[0] = vec2(1.0, 0.0);   // Right
-        neighborOffsets[1] = vec2(-1.0, 0.0);  // Left
-        neighborOffsets[2] = vec2(0.0, 1.0);   // Up
-        neighborOffsets[3] = vec2(0.0, -1.0);  // Down
+        // Links between live neighbors. These reflect the same eight-cell
+        // neighborhood the rule is evaluated over.
+        if (uLinkWidth > 0.0) {
+          float links = 0.0;
+          for (int i = 0; i < 8; i++) {
+            vec2 off = vec2(0.0);
+            if (i == 0) off = vec2( 1.0,  0.0);
+            if (i == 1) off = vec2(-1.0,  0.0);
+            if (i == 2) off = vec2( 0.0,  1.0);
+            if (i == 3) off = vec2( 0.0, -1.0);
+            if (i == 4) off = vec2( 1.0,  1.0);
+            if (i == 5) off = vec2(-1.0,  1.0);
+            if (i == 6) off = vec2( 1.0, -1.0);
+            if (i == 7) off = vec2(-1.0, -1.0);
 
-        for (int i = 0; i < 4; i++) {
-          vec2 neighborCell = cellPos + neighborOffsets[i];
-          vec2 neighborWorld = neighborCell * uCellSize;
-          float neighborState = getCellState(neighborWorld, adjustedTime);
-
-          // Connection strength based on state difference
-          float connectionStrength = abs(cellState - neighborState);
-          vec3 connectionColor = mix(cellColor, getAutomatonColor(neighborState), 0.5);
-
-          // Draw connection line
-          vec2 lineDir = neighborOffsets[i];
-          vec2 lineStart = localUv;
-          float lineProgress = dot(localUv, lineDir);
-
-          if (lineProgress > 0.0 && lineProgress < uCellSize * 0.5) {
-            vec2 perpDir = vec2(-lineDir.y, lineDir.x);
-            float distFromLine = abs(dot(localUv, perpDir));
-
-            float lineWidth = uConnectionLineWidth * (1.0 + connectionStrength * 2.0);
-            float lineBrightness = smoothstep(lineWidth * 2.0, lineWidth, distFromLine);
-
-            // Animate state updates - propagate through grid
-            vec2 updateDirection = vec2(sin(adjustedTime * 0.8), cos(adjustedTime * 0.6));
-            float updateWave = sin(dot(cellPos, updateDirection) * 2.0 - adjustedTime * uUpdateAnimationSpeed) * 0.5 + 0.5;
-            float updateBrightness = lineBrightness * (0.3 + 0.7 * updateWave);
-
-            finalColor += connectionColor * updateBrightness * connectionStrength * 1.5;
+            float na = cellAlpha(cell + off);
+            float dist = segmentDist(local, vec2(0.0), off * 0.5);
+            float line = 1.0 - smoothstep(0.0, uLinkWidth, dist);
+            links = max(links, line * na * alpha);
           }
+          color = mix(color, uColorGrid, links);
+          intensity = max(intensity, links * 0.55);
         }
 
-        // Draw diagonal neighbor connections for 8-neighbor automaton
-        vec2 diagonalOffsets[4];
-        diagonalOffsets[0] = vec2(1.0, 1.0);   // NE
-        diagonalOffsets[1] = vec2(-1.0, 1.0);  // NW
-        diagonalOffsets[2] = vec2(1.0, -1.0);  // SE
-        diagonalOffsets[3] = vec2(-1.0, -1.0); // SW
-
-        for (int i = 0; i < 4; i++) {
-          vec2 neighborCell = cellPos + diagonalOffsets[i];
-          vec2 neighborWorld = neighborCell * uCellSize;
-          float neighborState = getCellState(neighborWorld, adjustedTime);
-
-          float diagonalConnection = abs(cellState - neighborState) * uDiagonalConnectionWeight;
-          vec3 diagonalColor = mix(cellColor, getAutomatonColor(neighborState), 0.7);
-
-          vec2 lineDir = normalize(diagonalOffsets[i]);
-          float lineProgress = dot(localUv, lineDir);
-
-          if (lineProgress > 0.0 && lineProgress < uCellSize * 0.7) {
-            vec2 perpDir = vec2(-lineDir.y, lineDir.x);
-            float distFromLine = abs(dot(localUv, perpDir));
-
-            float lineWidth = 0.002 * (1.0 + diagonalConnection * 3.0);
-            float lineBrightness = smoothstep(lineWidth * 1.5, lineWidth, distFromLine);
-
-            finalColor += diagonalColor * lineBrightness * diagonalConnection * 0.8;
-          }
-        }
-
-        // Add cellular grid overlay
-        float gridLine = min(
-          smoothstep(0.002, 0.001, abs(localUv.x)),
-          smoothstep(0.002, 0.001, abs(localUv.y))
-        );
-        finalColor += uColorGrid * gridLine * 0.3;
-
-        // Highlight active evolution zones - sweeping across screen
-        float sweepPhase = sin(worldPos.x * 3.0 - adjustedTime * 4.0) * sin(worldPos.y * 2.0 - adjustedTime * 3.0);
-        float evolutionActivity = (sweepPhase * 0.5 + 0.5);
-
-        if (abs(cellState) > 0.2) {
-          finalColor += cellColor * evolutionActivity * uActivityIntensity;
-        }
-
-        gl_FragColor = vec4(finalColor * 1.0, 1.0);
+        color = mix(color, cellColor, body * alpha);
+        gl_FragColor = vec4(color * uActivityIntensity, intensity);
       }
     `;
 
-    // Create shader material with configurable uniforms
+    const stateTexture = buildGrid();
+    uploadState();
+
     const material = new THREE.ShaderMaterial({
       uniforms: {
-        uTime: { value: 0.0 },
-        // Match drawing buffer size (device pixels) to align with gl_FragCoord
-        uResolution: {
-          value: new THREE.Vector2(
-            renderer.domElement.width,
-            renderer.domElement.height
-          ),
-        },
-
-        // Standard settings mapped to uniforms
-        uCellBaseSize: { value: settings.elementSize },
-        uGlobalTimeMultiplier: { value: settings.globalTimeMultiplier },
-        uColorPrimary: { value: new THREE.Vector3(...settings.colors.primary) },
-        uColorSecondary: {
-          value: new THREE.Vector3(...settings.colors.secondary),
-        },
-        uColorAccent: { value: new THREE.Vector3(...settings.colors.accent) },
-        uColorBackground: {
-          value: new THREE.Vector3(...settings.colors.background),
-        },
-        uColorGrid: { value: new THREE.Vector3(...settings.colors.grid) },
-
-        // Custom cellular automaton settings
-        uCellSize: { value: settings.cellSize },
-        uCellSizeMultiplier: { value: settings.cellSizeMultiplier },
-        uEvolutionSpeed1: { value: settings.evolutionSpeed1 },
-        uEvolutionSpeed2: { value: settings.evolutionSpeed2 },
-        uDiagonalEvolutionSpeed: { value: settings.diagonalEvolutionSpeed },
-        uUpdateAnimationSpeed: { value: settings.updateAnimationSpeed },
-        uWaveAmplitude: { value: settings.waveAmplitude },
-        uConnectionLineWidth: { value: settings.connectionLineWidth },
-        uDiagonalConnectionWeight: { value: settings.diagonalConnectionWeight },
-        uActivityIntensity: { value: settings.activityIntensity },
+        uState: { value: stateTexture },
+        uGrid: { value: new THREE.Vector2(cols, rows) },
+        uStepProgress: { value: 1 },
+        uCellScale: { value: cellScale },
+        uLinkWidth: { value: connectionLineWidth },
+        uActivityIntensity: { value: activityIntensity },
+        uColorPrimary: { value: new THREE.Vector3(...colors.primary) },
+        uColorSecondary: { value: new THREE.Vector3(...colors.secondary) },
+        uColorAccent: { value: new THREE.Vector3(...colors.accent) },
+        uColorBackground: { value: new THREE.Vector3(...colors.background) },
+        uColorGrid: { value: new THREE.Vector3(...colors.grid) },
       },
       vertexShader,
       fragmentShader,
       transparent: true,
       blending: THREE.AdditiveBlending,
     });
+    materialRef.current = material;
 
-    // Create a plane geometry
     const geometry = new THREE.PlaneGeometry(2, 2);
-    const mesh = new THREE.Mesh(geometry, material);
-    scene.add(mesh);
+    scene.add(new THREE.Mesh(geometry, material));
 
-    // Animation loop
-    const animate = (time: number) => {
-      if (material.uniforms.uTime) {
-        material.uniforms.uTime.value = time * 0.001;
+    const stepIntervalMs = 1000 / Math.max(0.1, generationsPerSecond);
+    let lastStep = performance.now();
+    let lastPopulation = -1;
+    let stalledFor = 0;
+    let frameId: number | null = null;
+
+    const animate = (now: number) => {
+      const elapsed = now - lastStep;
+
+      if (elapsed >= stepIntervalMs) {
+        step();
+        uploadState();
+        lastStep = now;
+
+        // A grid whose population stops changing has converged on still lifes
+        // and short oscillators; reseed rather than sit on a frozen frame.
+        const live = population(current);
+        stalledFor = live === lastPopulation ? stalledFor + 1 : 0;
+        lastPopulation = live;
+        if (stalledFor >= STALL_GENERATIONS || live === 0) {
+          seed();
+          uploadState();
+          stalledFor = 0;
+          lastPopulation = -1;
+        }
       }
 
+      material.uniforms.uStepProgress.value = Math.min(
+        1,
+        (now - lastStep) / stepIntervalMs
+      );
       renderer.render(scene, camera);
-      animationFrameRef.current = requestAnimationFrame(animate);
+      frameId = requestAnimationFrame(animate);
     };
 
-    animate(0);
+    frameId = requestAnimationFrame(animate);
 
-    // Handle window resize
     const handleResize = () => {
-      if (renderer && material.uniforms.uResolution) {
-        renderer.setSize(window.innerWidth, window.innerHeight);
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-        material.uniforms.uResolution.value.set(
-          renderer.domElement.width,
-          renderer.domElement.height
-        );
-      }
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      const rebuilt = buildGrid();
+      uploadState();
+      material.uniforms.uState.value = rebuilt;
+      material.uniforms.uGrid.value.set(cols, rows);
     };
 
     window.addEventListener('resize', handleResize);
 
-    // Cleanup function
     return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-      }
-
+      if (frameId !== null) cancelAnimationFrame(frameId);
       window.removeEventListener('resize', handleResize);
-
-      if (container && renderer.domElement) {
+      if (container.contains(renderer.domElement)) {
         container.removeChild(renderer.domElement);
       }
-
-      // Clean up Three.js resources
+      texture?.dispose();
       geometry.dispose();
       material.dispose();
       renderer.dispose();
+      materialRef.current = null;
     };
-  }, [settings]);
+    // Cosmetic settings seed the uniforms here but are deliberately excluded
+    // from the dependency list — the effect below updates them in place so that
+    // nudging a color slider does not restart the simulation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rule, cellSize, generationsPerSecond, initialDensity]);
+
+  // Cosmetic updates go straight to uniforms, leaving the simulation running.
+  useEffect(() => {
+    const material = materialRef.current;
+    if (!material) return;
+    material.uniforms.uCellScale.value = cellScale;
+    material.uniforms.uLinkWidth.value = connectionLineWidth;
+    material.uniforms.uActivityIntensity.value = activityIntensity;
+    material.uniforms.uColorPrimary.value.set(...colors.primary);
+    material.uniforms.uColorSecondary.value.set(...colors.secondary);
+    material.uniforms.uColorAccent.value.set(...colors.accent);
+    material.uniforms.uColorBackground.value.set(...colors.background);
+    material.uniforms.uColorGrid.value.set(...colors.grid);
+  }, [cellScale, connectionLineWidth, activityIntensity, colors]);
 
   return (
     <div
@@ -348,7 +358,7 @@ const CellularAutomatonBackground: React.FC<
         height: '100vh',
         zIndex: -1,
         pointerEvents: 'none',
-        opacity: settings.opacity,
+        opacity,
       }}
     />
   );

--- a/src/components/animated-backgrounds/backgrounds/cellular-automaton/automaton.ts
+++ b/src/components/animated-backgrounds/backgrounds/cellular-automaton/automaton.ts
@@ -1,0 +1,74 @@
+/**
+ * Life-like cellular automaton core.
+ *
+ * Kept free of Three.js and React so the rule can be tested directly against
+ * known Conway patterns (blinker, block, glider) rather than inspected on a
+ * canvas.
+ */
+import { LIFE_RULES } from './config';
+
+export interface RuleTables {
+  /** birth[n] — a dead cell with n live neighbors becomes alive. */
+  birth: boolean[];
+  /** survival[n] — a live cell with n live neighbors stays alive. */
+  survival: boolean[];
+}
+
+/**
+ * Builds neighbor-count lookup tables for a rule id, falling back to Conway's
+ * Life when the id is unknown.
+ */
+export const makeRuleTables = (ruleId: string): RuleTables => {
+  const { birth, survival } = LIFE_RULES[ruleId] ?? LIFE_RULES.conway;
+  return {
+    birth: Array.from({ length: 9 }, (_, n) => birth.includes(n)),
+    survival: Array.from({ length: 9 }, (_, n) => survival.includes(n)),
+  };
+};
+
+/**
+ * Advances the grid one generation, writing into `next`.
+ *
+ * The grid is a torus: column and row indices wrap, so gliders leaving one edge
+ * re-enter on the opposite one and no cell is special-cased as a boundary.
+ */
+export const stepLife = (
+  current: Uint8Array,
+  next: Uint8Array,
+  cols: number,
+  rows: number,
+  tables: RuleTables
+): void => {
+  for (let y = 0; y < rows; y++) {
+    const yUp = ((y - 1 + rows) % rows) * cols;
+    const yDown = ((y + 1) % rows) * cols;
+    const yHere = y * cols;
+
+    for (let x = 0; x < cols; x++) {
+      const xLeft = (x - 1 + cols) % cols;
+      const xRight = (x + 1) % cols;
+
+      const n =
+        current[yUp + xLeft] +
+        current[yUp + x] +
+        current[yUp + xRight] +
+        current[yHere + xLeft] +
+        current[yHere + xRight] +
+        current[yDown + xLeft] +
+        current[yDown + x] +
+        current[yDown + xRight];
+
+      const idx = yHere + x;
+      next[idx] = (current[idx] === 1 ? tables.survival[n] : tables.birth[n])
+        ? 1
+        : 0;
+    }
+  }
+};
+
+/** Total live cells, used to detect a stalled grid. */
+export const population = (grid: Uint8Array): number => {
+  let live = 0;
+  for (let i = 0; i < grid.length; i++) live += grid[i];
+  return live;
+};

--- a/src/components/animated-backgrounds/backgrounds/cellular-automaton/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/cellular-automaton/config.ts
@@ -2,33 +2,57 @@ import { createBackgroundConfig } from '../../core/baseConfig';
 import { SettingsSchema, StandardSettings } from '../../core/types';
 import CellularAutomatonBackground from './CellularAutomatonBackground';
 
+/**
+ * Life-like rules in B/S notation: a dead cell is born when its live neighbor
+ * count appears in `birth`, and a live cell survives when its count appears in
+ * `survival`. Everything else dies. Shared by the settings schema and the
+ * simulation so the dropdown and the rule table cannot drift apart.
+ */
+export const LIFE_RULES: Record<
+  string,
+  { label: string; birth: number[]; survival: number[] }
+> = {
+  conway: { label: "Conway's Life (B3/S23)", birth: [3], survival: [2, 3] },
+  highlife: { label: 'HighLife (B36/S23)', birth: [3, 6], survival: [2, 3] },
+  maze: {
+    label: 'Maze (B3/S12345)',
+    birth: [3],
+    survival: [1, 2, 3, 4, 5],
+  },
+  coral: {
+    label: 'Coral (B3/S45678)',
+    birth: [3],
+    survival: [4, 5, 6, 7, 8],
+  },
+  daynight: {
+    label: 'Day & Night (B3678/S34678)',
+    birth: [3, 6, 7, 8],
+    survival: [3, 4, 6, 7, 8],
+  },
+  seeds: { label: 'Seeds (B2/S)', birth: [2], survival: [] },
+};
+
 // Custom settings specific to cellular automaton
 export interface CellularAutomatonCustomSettings {
-  // Grid and cell properties
-  cellSize: number;
-  cellSizeMultiplier: number;
+  // Simulation
+  rule: string;
+  cellSize: number; // CSS pixels per cell
+  generationsPerSecond: number;
+  initialDensity: number; // Fraction of cells alive in the starting soup
+  perturbationRate: number; // Fraction of cells randomly flipped per generation
 
-  // Evolution speeds
-  evolutionSpeed1: number;
-  evolutionSpeed2: number;
-  diagonalEvolutionSpeed: number;
-  updateAnimationSpeed: number;
-
-  // Wave properties
-  waveAmplitude: number;
-
-  // Connection properties
-  connectionLineWidth: number;
-  diagonalConnectionWeight: number;
+  // Rendering
+  cellScale: number; // Cell fill size as a fraction of its grid square
+  connectionLineWidth: number; // 0 disables neighbor links
   activityIntensity: number;
 
   // Colors specific to cellular automaton
   colors: {
-    primary: [number, number, number]; // Forest green for alive cells
-    secondary: [number, number, number]; // Warm orange for active cells
-    accent: [number, number, number]; // Golden yellow for high activity
-    background: [number, number, number]; // Dark blue-gray for empty space
-    grid: [number, number, number]; // Subtle grid lines
+    primary: [number, number, number]; // Established cells
+    secondary: [number, number, number]; // Newly born cells
+    accent: [number, number, number]; // Long-lived cells
+    background: [number, number, number]; // Empty space
+    grid: [number, number, number]; // Neighbor links
   };
 }
 
@@ -37,157 +61,130 @@ export type CellularAutomatonSettings = StandardSettings &
 
 // Default custom settings for cellular automaton
 const defaultCustomSettings: CellularAutomatonCustomSettings = {
-  // Grid and cell properties - zoomed out for better overview
-  cellSize: 0.006, // Much smaller cells for more detail
-  cellSizeMultiplier: 0.08, // Moderate size variation
+  // Simulation - slow enough to read as structure rather than static
+  rule: 'conway',
+  cellSize: 22,
+  generationsPerSecond: 3,
+  initialDensity: 0.32,
+  perturbationRate: 0.0006,
 
-  // Evolution speeds - slower for observable growth dynamics
-  evolutionSpeed1: 1.2,
-  evolutionSpeed2: 1.8,
-  diagonalEvolutionSpeed: 2.5,
-  updateAnimationSpeed: 2.0,
-
-  // Wave properties - more concentrated patterns
-  waveAmplitude: 1.2,
-
-  // Connection properties - enhanced for concentrated growth
-  connectionLineWidth: 0.012,
-  diagonalConnectionWeight: 0.6,
-  activityIntensity: 1.4,
+  // Rendering
+  cellScale: 0.55,
+  connectionLineWidth: 0.06,
+  activityIntensity: 1.2,
 
   // Organic color scheme for cellular automaton
   colors: {
-    primary: [0.1, 0.8, 0.3], // Forest green for alive cells
-    secondary: [0.9, 0.4, 0.1], // Warm orange for active cells
-    accent: [1.0, 0.7, 0.2], // Golden yellow for high activity
-    background: [0.15, 0.15, 0.2], // Dark blue-gray for empty space
-    grid: [0.25, 0.3, 0.35], // Subtle grid lines
+    primary: [0.1, 0.8, 0.3], // Established cells
+    secondary: [0.9, 0.4, 0.1], // Newly born cells
+    accent: [1.0, 0.7, 0.2], // Long-lived cells
+    background: [0.15, 0.15, 0.2], // Empty space
+    grid: [0.25, 0.3, 0.35], // Neighbor links
   },
 };
 
 // Standard settings overrides for cellular automaton
 const standardOverrides: Partial<StandardSettings> = {
   opacity: 0.75, // Less overpowering
-  elementSize: 0.03, // Smaller base cell size
-  globalTimeMultiplier: 0.4, // Very slow global time
+  elementSize: 0.03,
+  globalTimeMultiplier: 0.4,
 };
 
 // Settings schema for custom cellular automaton settings
 const customSettingsSchema: SettingsSchema[] = [
-  // Grid and Cell Properties
+  // Simulation
+  {
+    key: 'rule',
+    label: 'Rule',
+    type: 'select',
+    options: Object.entries(LIFE_RULES).map(([value, { label }]) => ({
+      value,
+      label,
+    })),
+    category: 'Simulation',
+  },
   {
     key: 'cellSize',
-    label: 'Cell Size',
+    label: 'Cell Size (px)',
     type: 'slider',
-    min: 0.02,
-    max: 0.15,
-    step: 0.005,
-    category: 'Cellular Automaton',
+    min: 8,
+    max: 48,
+    step: 1,
+    category: 'Simulation',
   },
   {
-    key: 'cellSizeMultiplier',
-    label: 'Cell Size Response',
+    key: 'generationsPerSecond',
+    label: 'Generations per Second',
     type: 'slider',
-    min: 0.01,
-    max: 0.08,
-    step: 0.001,
-    category: 'Cellular Automaton',
+    min: 0.5,
+    max: 20,
+    step: 0.5,
+    category: 'Simulation',
+  },
+  {
+    key: 'initialDensity',
+    label: 'Initial Density',
+    type: 'slider',
+    min: 0.05,
+    max: 0.8,
+    step: 0.01,
+    category: 'Simulation',
+  },
+  {
+    key: 'perturbationRate',
+    label: 'Perturbation Rate',
+    type: 'slider',
+    min: 0,
+    max: 0.01,
+    step: 0.0002,
+    category: 'Simulation',
   },
 
-  // Evolution Speeds
+  // Rendering
   {
-    key: 'evolutionSpeed1',
-    label: 'Primary Evolution Speed',
+    key: 'cellScale',
+    label: 'Cell Fill',
     type: 'slider',
-    min: 1.0,
-    max: 10.0,
-    step: 0.5,
-    category: 'Evolution',
-  },
-  {
-    key: 'evolutionSpeed2',
-    label: 'Secondary Evolution Speed',
-    type: 'slider',
-    min: 1.0,
-    max: 10.0,
-    step: 0.5,
-    category: 'Evolution',
-  },
-  {
-    key: 'diagonalEvolutionSpeed',
-    label: 'Diagonal Evolution Speed',
-    type: 'slider',
-    min: 1.0,
-    max: 12.0,
-    step: 0.5,
-    category: 'Evolution',
-  },
-  {
-    key: 'updateAnimationSpeed',
-    label: 'Update Animation Speed',
-    type: 'slider',
-    min: 2.0,
-    max: 15.0,
-    step: 0.5,
-    category: 'Evolution',
-  },
-
-  // Wave Properties
-  {
-    key: 'waveAmplitude',
-    label: 'Evolution Amplitude',
-    type: 'slider',
-    min: 0.1,
+    min: 0.2,
     max: 1.0,
     step: 0.05,
-    category: 'Evolution',
+    category: 'Visual Effects',
   },
-
-  // Connection Properties
   {
     key: 'connectionLineWidth',
-    label: 'Connection Line Width',
+    label: 'Neighbor Link Width',
     type: 'slider',
-    min: 0.001,
-    max: 0.01,
-    step: 0.0005,
-    category: 'Connections',
-  },
-  {
-    key: 'diagonalConnectionWeight',
-    label: 'Diagonal Connection Weight',
-    type: 'slider',
-    min: 0.1,
-    max: 0.8,
-    step: 0.05,
-    category: 'Connections',
+    min: 0,
+    max: 0.2,
+    step: 0.01,
+    category: 'Visual Effects',
   },
   {
     key: 'activityIntensity',
     label: 'Activity Intensity',
     type: 'slider',
-    min: 0.0,
-    max: 1.0,
-    step: 0.05,
-    category: 'Connections',
+    min: 0.5,
+    max: 3.0,
+    step: 0.1,
+    category: 'Visual Effects',
   },
 
   // Color settings specific to cellular automaton
   {
     key: 'colors.primary',
-    label: 'Alive Cell Color',
+    label: 'Established Cell Color',
     type: 'color',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
-    label: 'Active Cell Color',
+    label: 'Newborn Cell Color',
     type: 'color',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
-    label: 'High Activity Color',
+    label: 'Long-Lived Cell Color',
     type: 'color',
     category: 'Colors',
   },
@@ -199,7 +196,7 @@ const customSettingsSchema: SettingsSchema[] = [
   },
   {
     key: 'colors.grid',
-    label: 'Grid Color',
+    label: 'Neighbor Link Color',
     type: 'color',
     category: 'Colors',
   },
@@ -210,7 +207,7 @@ export const cellularAutomatonConfig = createBackgroundConfig({
   id: 'cellular-automaton',
   name: 'Cellular Automaton',
   description:
-    'Study of emergence: how simple local rules create complex global patterns. Each cell follows basic survival rules based on neighbor states, yet large populations exhibit sophisticated behaviors impossible to predict from individual interactions. Demonstrates how biological systems, neural networks, and distributed systems generate complex behaviors from simple components. Green cells show stable populations, orange indicates active growth, golden highlights mark evolutionary pressure zones.',
+    'A real Life-like cellular automaton: a grid of cells, a rule in B/S notation, and a state buffer stepped one generation at a time. Each cell counts its eight neighbors on a wrapping torus, then lives, dies, or is born according to Rule. Newborn cells take the newborn color, cells that have survived a while shift toward the long-lived color, and links are drawn between live neighbors. Random soup under Conway settles into still lifes and oscillators within a couple of hundred generations, so Perturbation Rate flips a small fraction of cells each step to keep it from freezing — turn it to zero to watch it stall on its own.',
   component: CellularAutomatonBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/cellular-automaton/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/cellular-automaton/config.ts
@@ -101,6 +101,8 @@ const customSettingsSchema: SettingsSchema[] = [
       value,
       label,
     })),
+    description:
+      "The birth/survival rule in B/S notation: a dead cell is born on a neighbour count in B, a live one survives on a count in S. B3/S23 is Conway's Life. Seeds (B2/S) has no survival counts at all, so every live cell dies each step and the pattern is pure recurrent birth — by far the most volatile option.",
     category: 'Simulation',
   },
   {
@@ -110,6 +112,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 8,
     max: 48,
     step: 1,
+    description:
+      'Pixels per cell, which decides how many cells fit on screen. Smaller cells give a larger grid and finer structure, at more work per generation.',
     category: 'Simulation',
   },
   {
@@ -119,6 +123,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 20,
     step: 0.5,
+    description:
+      'How often the rule is applied. Low values let you follow individual births and deaths; high values blur into texture.',
     category: 'Simulation',
   },
   {
@@ -128,6 +134,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.05,
     max: 0.8,
     step: 0.01,
+    description:
+      'Fraction of cells alive in the starting soup. Conway is liveliest near 0.3 — much denser and the first few generations mostly die back to the same still lifes.',
     category: 'Simulation',
   },
   {
@@ -137,6 +145,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0,
     max: 0.01,
     step: 0.0002,
+    description:
+      'Fraction of cells switched on at random each generation. Random soup under most rules settles into still lifes and period-two oscillators within a couple of hundred generations; this keeps it moving. Set it to zero to watch the grid stall on its own, which is the honest behaviour.',
     category: 'Simulation',
   },
 
@@ -148,6 +158,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.2,
     max: 1.0,
     step: 0.05,
+    description:
+      'How much of its grid square a live cell fills. Low values read as separated dots; near 1.0 neighbouring cells merge into solid regions.',
     category: 'Visual Effects',
   },
   {
@@ -157,6 +169,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0,
     max: 0.2,
     step: 0.01,
+    description:
+      'Thickness of the links drawn between live neighbours. They trace the same eight-cell neighbourhood the rule is evaluated over. Zero hides them entirely.',
     category: 'Visual Effects',
   },
   {
@@ -166,6 +180,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 3.0,
     step: 0.1,
+    description: 'Overall brightness multiplier for the grid.',
     category: 'Visual Effects',
   },
 
@@ -174,30 +189,38 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.primary',
     label: 'Established Cell Color',
     type: 'color',
+    description:
+      'Cells that have survived several generations — the stable structures.',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
     label: 'Newborn Cell Color',
     type: 'color',
+    description:
+      'Newly born cells. Strong contrast against the established colour makes the growing edge of a pattern obvious.',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
     label: 'Long-Lived Cell Color',
     type: 'color',
+    description:
+      'The colour long-lived cells drift toward, marking the still lifes that have stopped changing.',
     category: 'Colors',
   },
   {
     key: 'colors.background',
     label: 'Background Color',
     type: 'color',
+    description: 'Empty space, where no cell is alive.',
     category: 'Colors',
   },
   {
     key: 'colors.grid',
     label: 'Neighbor Link Color',
     type: 'color',
+    description: 'The links drawn between live neighbours.',
     category: 'Colors',
   },
 ];

--- a/src/components/animated-backgrounds/backgrounds/graph-topology/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/graph-topology/config.ts
@@ -151,7 +151,7 @@ export const graphTopologyConfig = createBackgroundConfig({
   id: 'graph-topology',
   name: 'Job Scheduling',
   description:
-    'Graph-based resource allocation algorithm solving the distributed computing challenge of efficiently assigning jobs to optimal infrastructure clusters. Searches network topology for highly-connected subgraphs - groups of servers, containers, or VMs with strong interconnections that can handle workload requirements. Golden paths show active topology exploration, bright cyan highlights discovered optimal clusters. Powers container orchestration, cloud resource management, and high-performance computing job scheduling.',
+    'Simulated annealing over a clustered graph. The topology is built like a datacenter: dense high-bandwidth links inside each cluster, sparse high-latency links between them. The search looks for the subgraph of the requested size with the highest total conductivity, proposing swaps and accepting worse ones with a temperature-dependent probability that decays on an exponential cooling schedule. Gold is the candidate set under consideration right now; cyan is the best set found so far. Early on they diverge constantly, then lock together as the temperature drops. Layout is force-directed and still settling while the search runs.',
   component: GraphTopologyBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/graph-topology/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/graph-topology/config.ts
@@ -65,6 +65,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 16,
     max: 64,
     step: 4,
+    description:
+      'Number of machines in the simulated network. More nodes make the search harder and the layout busier.',
     category: 'Graph Topology',
   },
   {
@@ -74,6 +76,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 2,
     max: 6,
     step: 1,
+    description:
+      'How many tightly connected groups the network splits into — think racks or availability zones, dense inside and sparse between.',
     category: 'Graph Topology',
   },
   {
@@ -83,6 +87,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 3,
     max: 16,
     step: 1,
+    description:
+      "How many nodes the search must select. Set it near one cluster's worth to watch the annealer commit to a single cluster; set it larger and it is forced to span clusters and pay the latency between them.",
     category: 'Graph Topology',
   },
   {
@@ -92,6 +98,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 2.0,
     step: 0.1,
+    description:
+      'Spreads the layout out or pulls it in. Purely visual; it does not affect the search.',
     category: 'Graph Topology',
   },
   {
@@ -101,6 +109,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.2,
     max: 3.0,
     step: 0.1,
+    description:
+      'How fast the annealer proposes swaps. Slow it down to see individual accept and reject decisions.',
     category: 'Algorithm',
   },
   {
@@ -110,6 +120,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 5.0,
     step: 0.25,
+    description: "Line weight for the network's links.",
     category: 'Graph Topology',
   },
 
@@ -118,30 +129,31 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.primary',
     label: 'Optimal Subgraph Color',
     type: 'color',
+    description:
+      'The best subgraph found so far. Late in a run it stops changing.',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
     label: 'Current Search Color',
     type: 'color',
+    description:
+      'The candidate set under consideration right now. Early on, while the temperature is high, it jumps around constantly.',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
     label: 'Convergence Color',
     type: 'color',
+    description:
+      'Where the current candidate and the best-known set agree. The two lock together as the temperature drops.',
     category: 'Colors',
   },
   {
     key: 'colors.background',
     label: 'Background Color',
     type: 'color',
-    category: 'Colors',
-  },
-  {
-    key: 'colors.grid',
-    label: 'Grid Color',
-    type: 'color',
+    description: 'Canvas colour behind the graph.',
     category: 'Colors',
   },
 ];

--- a/src/components/animated-backgrounds/backgrounds/pde-solver/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/pde-solver/config.ts
@@ -91,6 +91,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 'heat', label: 'Heat Equation (Diffusion)' },
       { value: 'wave', label: 'Wave Equation (Propagation)' },
     ],
+    description:
+      'Heat diffuses and smooths an initial distribution out; the wave equation propagates and reflects it. Same grid and same solver, different physics.',
     category: 'PDE Configuration',
   },
 
@@ -102,6 +104,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.01,
     max: 0.5,
     step: 0.01,
+    description:
+      'Thermal diffusivity in the heat equation — how fast heat spreads. The timestep is clamped to the stability limit, so pushing this slows the simulation down rather than making it diverge.',
     category: 'Physical Parameters',
   },
   {
@@ -111,6 +115,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 3.0,
     step: 0.1,
+    description:
+      'Propagation speed in the wave equation. Bound by the CFL condition, so very high values shrink the timestep instead of outrunning the grid.',
     category: 'Physical Parameters',
   },
   {
@@ -120,6 +126,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 0.05,
     step: 0.001,
+    description:
+      'Bleeds energy out of the system each step. At zero energy is conserved and waves ring indefinitely.',
     category: 'Physical Parameters',
   },
 
@@ -133,6 +141,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 128, label: '128×128 (Balanced)' },
       { value: 256, label: '256×256 (Detailed)' },
     ],
+    description:
+      'Resolution of the simulation grid. Higher resolves finer detail at roughly four times the work per step for each doubling.',
     category: 'Grid Configuration',
   },
 
@@ -149,6 +159,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 'interference', label: 'Interference Pattern' },
       { value: 'random', label: 'Random Noise' },
     ],
+    description:
+      'The state the solver starts from. A Gaussian pulse is the cleanest way to see boundary reflections; interference starts with several sources already overlapping.',
     category: 'Initial Conditions',
   },
   {
@@ -158,6 +170,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 2.0,
     step: 0.1,
+    description: 'Height of the initial disturbance.',
     category: 'Initial Conditions',
   },
   {
@@ -167,6 +180,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 1.0,
     max: 10.0,
     step: 0.5,
+    description:
+      'Spatial frequency of the sine and interference initial conditions.',
     category: 'Initial Conditions',
   },
   {
@@ -176,6 +191,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.02,
     max: 0.3,
     step: 0.01,
+    description:
+      'Width of the Gaussian, square and ring initial conditions. Narrow pulses contain higher spatial frequencies and show grid dispersion sooner.',
     category: 'Initial Conditions',
   },
   {
@@ -185,6 +202,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 2,
     max: 8,
     step: 1,
+    description:
+      'How many sources the interference initial condition starts with.',
     category: 'Initial Conditions',
   },
 
@@ -198,6 +217,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 'neumann', label: 'Neumann (Free)' },
       { value: 'periodic', label: 'Periodic (Wrap)' },
     ],
+    description:
+      'What happens at the left and right edges. Dirichlet fixes the value there, so waves reflect inverted; Neumann fixes the derivative, so they reflect upright; Periodic wraps, so anything leaving one edge arrives at the other. Switching between the three with a Gaussian pulse on the wave equation is the clearest demonstration of what a boundary condition actually does.',
     category: 'Boundary Conditions',
   },
   {
@@ -209,6 +230,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 'neumann', label: 'Neumann (Free)' },
       { value: 'periodic', label: 'Periodic (Wrap)' },
     ],
+    description:
+      'The same choice for the top and bottom edges. Setting the two axes differently — periodic in x, Dirichlet in y — makes a waveguide.',
     category: 'Boundary Conditions',
   },
 
@@ -223,6 +246,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 'wave', label: 'Wave (Blue-Red)' },
       { value: 'monochrome', label: 'Monochrome' },
     ],
+    description:
+      'Palette mapping field value to colour. Thermal suits the heat equation; the blue-red scale is diverging, so it distinguishes positive from negative better for waves.',
     category: 'Visualization',
   },
   {
@@ -232,6 +257,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 0.5,
     step: 0.01,
+    description:
+      'Displaces the surface vertically by field value, turning the plot into a relief. Zero renders it flat.',
     category: 'Visualization',
   },
   {
@@ -242,6 +269,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: true, label: 'Yes' },
       { value: false, label: 'No' },
     ],
+    description:
+      'Draws the grid the solver actually computes on, rather than a smooth surface.',
     category: 'Visualization',
   },
   {
@@ -252,6 +281,7 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: true, label: 'Yes' },
       { value: false, label: 'No' },
     ],
+    description: 'Slowly orbits the camera around the surface.',
     category: 'Visualization',
   },
   {
@@ -261,6 +291,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 2.0,
     step: 0.1,
+    description: 'How fast the view rotates when auto-rotate is on.',
     category: 'Visualization',
   },
 
@@ -269,18 +300,22 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.positive',
     label: 'Positive Value Color',
     type: 'color',
+    description: 'Colour for values above zero — hot regions, or wave crests.',
     category: 'Colors',
   },
   {
     key: 'colors.negative',
     label: 'Negative Value Color',
     type: 'color',
+    description:
+      'Colour for values below zero. Only the wave equation goes negative; heat with a positive initial condition stays above zero.',
     category: 'Colors',
   },
   {
     key: 'colors.zero',
     label: 'Zero Value Color',
     type: 'color',
+    description: 'Colour at zero, the midpoint of the scale.',
     category: 'Colors',
   },
 ];

--- a/src/components/animated-backgrounds/backgrounds/pde-solver/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/pde-solver/config.ts
@@ -290,12 +290,13 @@ export const pdeSolverConfig = createBackgroundConfig({
   id: 'pde-solver',
   name: 'PDE Solver: Heat & Wave Equations',
   description:
-    'Mathematically rigorous visualization of Partial Differential Equations using finite difference methods. ' +
-    'Heat Equation (∂u/∂t = α∇²u) models thermal diffusion, chemical diffusion, and stochastic processes. ' +
-    'Wave Equation (∂²u/∂t² = c²∇²u) models electromagnetic waves, sound propagation, quantum mechanics, and string vibrations. ' +
-    'Features configurable boundary conditions (Dirichlet, Neumann, Periodic), multiple initial conditions, ' +
-    'and real-time 3D visualization. Built with stability-checked FTCS and CFL-compliant schemes. ' +
-    'Essential for understanding heat transfer, wave phenomena, quantum wavefunctions, and numerical analysis.',
+    'Explicit finite differences on a grid, solving the heat equation (∂u/∂t = α∇²u) or the wave equation ' +
+    '(∂²u/∂t² = c²∇²u). The Laplacian is a five-point stencil; heat uses FTCS, wave a centered second difference in time. ' +
+    'Boundary Condition and Initial Condition are the settings that change the physics rather than the look — Dirichlet ' +
+    'fixes the edge value so waves reflect inverted, Neumann zeroes the edge derivative so they reflect upright, and ' +
+    'Periodic wraps. Try a Gaussian pulse on the wave equation and switch between the three. You cannot make it diverge: ' +
+    'explicit schemes are only conditionally stable, so the timestep is clamped to the CFL limit before every step and ' +
+    'pushing diffusivity too far slows the simulation instead.',
   component: PDESolverBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/pde-solver/types.ts
+++ b/src/components/animated-backgrounds/backgrounds/pde-solver/types.ts
@@ -6,9 +6,9 @@
 export type EquationType = 'heat' | 'wave';
 
 export type BoundaryConditionType =
-  | 'dirichlet'    // Fixed values at boundaries
-  | 'neumann'      // Fixed derivative at boundaries
-  | 'periodic';    // Periodic boundaries
+  | 'dirichlet' // Fixed values at boundaries
+  | 'neumann' // Fixed derivative at boundaries
+  | 'periodic'; // Periodic boundaries
 
 export type InitialConditionType =
   | 'gaussian'
@@ -23,8 +23,8 @@ export type InitialConditionType =
  */
 export interface BoundaryCondition {
   type: BoundaryConditionType;
-  value?: number;  // For Dirichlet conditions
-  derivative?: number;  // For Neumann conditions
+  value?: number; // For Dirichlet conditions
+  derivative?: number; // For Neumann conditions
 }
 
 /**
@@ -33,11 +33,11 @@ export interface BoundaryCondition {
 export interface InitialCondition {
   type: InitialConditionType;
   amplitude: number;
-  frequency?: number;  // For sine/cosine
-  width?: number;  // For Gaussian
+  frequency?: number; // For sine/cosine
+  width?: number; // For Gaussian
   centerX?: number;
   centerY?: number;
-  numSources?: number;  // For interference patterns
+  numSources?: number; // For interference patterns
 }
 
 /**
@@ -49,13 +49,13 @@ export interface PDESolverConfig {
   gridSizeY: number;
 
   // Physical parameters
-  dx: number;  // Spatial step size
-  dy: number;  // Spatial step size
-  dt: number;  // Time step size
+  dx: number; // Spatial step size
+  dy: number; // Spatial step size
+  dt: number; // Time step size
 
   // Equation-specific parameters
-  alpha?: number;  // Thermal diffusivity (heat equation)
-  c?: number;      // Wave speed (wave equation)
+  alpha?: number; // Thermal diffusivity (heat equation)
+  c?: number; // Wave speed (wave equation)
 
   // Boundary conditions
   boundaryX: BoundaryCondition;
@@ -63,10 +63,10 @@ export interface PDESolverConfig {
 
   // Initial conditions
   initialCondition: InitialCondition;
-  initialVelocity?: InitialCondition;  // For wave equation
+  initialVelocity?: InitialCondition; // For wave equation
 
   // Simulation parameters
-  damping?: number;  // Energy dissipation (0-1)
+  damping?: number; // Energy dissipation (0-1)
 }
 
 /**
@@ -74,10 +74,10 @@ export interface PDESolverConfig {
  */
 export interface PDEState {
   // Current field values
-  u: Float32Array;  // Current state
+  u: Float32Array; // Current state
 
   // For wave equation (requires previous state)
-  uPrev?: Float32Array;  // Previous state (t - dt)
+  uPrev?: Float32Array; // Previous state (t - dt)
 
   // Grid parameters
   gridSizeX: number;
@@ -95,5 +95,5 @@ export interface PDESolveResult {
   state: PDEState;
   maxValue: number;
   minValue: number;
-  energy: number;  // Total energy in the system
+  energy: number; // Total energy in the system
 }

--- a/src/components/animated-backgrounds/backgrounds/shortest-path-lab/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/shortest-path-lab/config.ts
@@ -275,7 +275,7 @@ export const shortestPathLabConfig = createBackgroundConfig({
   id: 'shortest-path-lab',
   name: 'Shortest Path (Dijkstra/A*)',
   description:
-    "Comparative visualization of pathfinding algorithms that power GPS navigation, internet routing, and game AI. Dijkstra's algorithm (weight = 0) systematically explores all possibilities to guarantee optimal paths. A* (weight = 1) uses distance heuristics to find optimal paths faster. Greedy search (weight > 1) sacrifices optimality for speed. Yellow patterns show exploration strategy: uniform for Dijkstra, directionally-biased for A*, narrow for greedy. Blue highlights the discovered optimal route. Demonstrates the fundamental trade-off between computational thoroughness and execution speed in network optimization.",
+    'Dijkstra, A*, and greedy best-first are the same search with one number changed. Heuristic Weight scales w in f = g + w*h: at 0 the heuristic vanishes and this is Dijkstra, at 1 it is A* with an admissible heuristic, above 1 it over-trusts the heuristic and gives up the optimality guarantee for speed. Watch the shape of the explored region rather than the path — a circle, then an ellipse, then a corridor. Yellow is explored, blue is the route found. Drop Steps per Second to about 5 to follow the frontier node by node.',
   component: ShortestPathLabBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/shortest-path-lab/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/shortest-path-lab/config.ts
@@ -93,6 +93,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 10,
     max: 80,
     step: 2,
+    description: 'Number of nodes in the randomly generated graph.',
     category: 'Graph',
   },
   {
@@ -102,6 +103,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.05,
     max: 0.6,
     step: 0.01,
+    description:
+      'What fraction of possible edges exist. Sparse graphs force long detours and make the algorithms differ more; dense ones make almost every route short.',
     category: 'Graph',
   },
   {
@@ -111,6 +114,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0,
     max: 79,
     step: 1,
+    description: 'Index of the node the search starts from.',
     category: 'Graph',
   },
   {
@@ -120,6 +124,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0,
     max: 79,
     step: 1,
+    description:
+      'Index of the node it is trying to reach. The further it is from the start, the more visible the difference between the algorithms.',
     category: 'Graph',
   },
 
@@ -131,6 +137,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 3.0,
     step: 0.05,
+    description:
+      'Scales w in f = g + w·h, which is the only thing separating these algorithms. At 0 the heuristic vanishes and this is Dijkstra, exploring evenly in every direction. At 1 it is A*: still guaranteed optimal, but exploration stretches toward the goal. Above 1 it over-trusts the heuristic, drives almost straight at the goal, and gives up the optimality guarantee. Watch the shape of the explored region rather than the path — a circle, then an ellipse, then a corridor.',
     category: 'Algorithm',
   },
   {
@@ -140,6 +148,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 12.0,
     step: 0.5,
+    description:
+      'How many nodes the search expands per second. Drop it to around 5 to follow the frontier one node at a time.',
     category: 'Algorithm',
   },
   {
@@ -149,6 +159,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.2,
     max: 10.0,
     step: 0.2,
+    description:
+      'Speed of the dot that retraces the route once the search has finished.',
     category: 'Algorithm',
   },
 
@@ -160,6 +172,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.05,
     max: 0.8,
     step: 0.05,
+    description:
+      'Opacity of edges the search has not touched — the backdrop it happens over.',
     category: 'Visual Effects',
   },
   {
@@ -169,6 +183,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 4.0,
     step: 0.25,
+    description: 'Line weight for untouched edges.',
     category: 'Visual Effects',
   },
   {
@@ -178,6 +193,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 1.0,
     max: 8.0,
     step: 0.25,
+    description:
+      'Line weight for edges the search has explored. This is what makes the explored region legible, so it is the one to raise if you are watching the frontier.',
     category: 'Visual Effects',
   },
   {
@@ -187,6 +204,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 4,
     max: 24,
     step: 1,
+    description: 'Size of the dot that traces the final route.',
     category: 'Visual Effects',
   },
   {
@@ -196,6 +214,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'Glow around that dot.',
     category: 'Visual Effects',
   },
 
@@ -207,6 +226,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0,
     max: 1,
     step: 1,
+    description: 'Toggles the bloom post-process. Off is cheaper and sharper.',
     category: 'Post-Processing',
   },
   {
@@ -216,6 +236,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 3.0,
     step: 0.05,
+    description: 'How intensely bright areas bloom.',
     category: 'Post-Processing',
   },
   {
@@ -225,6 +246,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.01,
+    description: 'How far the bloom spreads from its source.',
     category: 'Post-Processing',
   },
   {
@@ -234,6 +256,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.01,
+    description:
+      'How bright a pixel must be before it blooms at all. Raise it to confine the glow to the final path.',
     category: 'Post-Processing',
   },
 
@@ -242,30 +266,29 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.primary',
     label: 'Final Path Color',
     type: 'color',
+    description: 'The shortest route, once the search has found it.',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
     label: 'Exploration Color',
     type: 'color',
+    description:
+      'Nodes and edges the search has explored. This is the region whose shape tells you which algorithm is running.',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
     label: 'Start/Goal Color',
     type: 'color',
+    description: 'The start and goal nodes.',
     category: 'Colors',
   },
   {
     key: 'colors.background',
     label: 'Background Color',
     type: 'color',
-    category: 'Colors',
-  },
-  {
-    key: 'colors.grid',
-    label: 'Grid Color',
-    type: 'color',
+    description: 'Canvas colour behind the graph.',
     category: 'Colors',
   },
 ];

--- a/src/components/animated-backgrounds/backgrounds/simple-waves/SimpleWaveBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/simple-waves/SimpleWaveBackground.tsx
@@ -48,6 +48,7 @@ const SimpleWaveBackground: React.FC<
       uniform vec3 uColorPrimary;
       uniform vec3 uColorSecondary;
       uniform vec3 uColorAccent;
+      uniform vec3 uColorBackground;
 
       varying vec2 vUv;
 
@@ -76,6 +77,13 @@ const SimpleWaveBackground: React.FC<
         float brightness = 0.8 + 0.4 * sin(uv.x * 3.0 + time * 0.5) * sin(uv.y * 2.0 + time * 0.3);
         color *= brightness;
 
+        // Fade toward the background colour where the three components cancel.
+        // Without this the background colour has nowhere to show: the wave
+        // fills every pixel, so total destructive interference still painted a
+        // wave colour rather than reading as empty.
+        float energy = smoothstep(0.0, 0.35, abs(combined));
+        color = mix(uColorBackground, color, energy);
+
         gl_FragColor = vec4(color, 1.0);
       }
     `;
@@ -95,6 +103,9 @@ const SimpleWaveBackground: React.FC<
           value: new THREE.Vector3(...settings.colors.secondary),
         },
         uColorAccent: { value: new THREE.Vector3(...settings.colors.accent) },
+        uColorBackground: {
+          value: new THREE.Vector3(...settings.colors.background),
+        },
       },
       vertexShader,
       fragmentShader,

--- a/src/components/animated-backgrounds/backgrounds/simple-waves/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/simple-waves/config.ts
@@ -49,6 +49,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 1.0,
     max: 20.0,
     step: 0.5,
+    description:
+      'Spatial frequency of all three components at once. Higher packs more interference fringes into the screen.',
     category: 'Wave Properties',
   },
   {
@@ -58,6 +60,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 2.0,
     step: 0.1,
+    description:
+      'Height of each component before they are summed. Larger amplitudes push more of the screen into full constructive or destructive interference and flatten the mid-tones.',
     category: 'Wave Properties',
   },
 
@@ -66,30 +70,29 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.primary',
     label: 'Primary Wave Color',
     type: 'color',
+    description: 'Mid amplitudes, where the components partly cancel.',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
     label: 'Secondary Wave Color',
     type: 'color',
+    description: 'Strong negative amplitude — troughs.',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
     label: 'Accent Wave Color',
     type: 'color',
+    description:
+      'Strong positive amplitude, where all three components reinforce.',
     category: 'Colors',
   },
   {
     key: 'colors.background',
     label: 'Background Color',
     type: 'color',
-    category: 'Colors',
-  },
-  {
-    key: 'colors.grid',
-    label: 'Grid Color',
-    type: 'color',
+    description: 'Shown where the three components cancel out completely.',
     category: 'Colors',
   },
 ];

--- a/src/components/animated-backgrounds/backgrounds/simple-waves/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/simple-waves/config.ts
@@ -99,7 +99,7 @@ export const simpleWaveConfig = createBackgroundConfig({
   id: 'simple-waves',
   name: 'Simple Sine Waves',
   description:
-    'Visualization of wave interference - the fundamental physics governing sound, light, radio, and quantum mechanics. Multiple sine waves combine through superposition, creating constructive interference (bright warm colors) when waves align, destructive interference (dark cool colors) when they cancel. Essential for understanding audio processing, signal analysis, noise cancellation, and communications systems. Colors map wave amplitude: bright indicates reinforcement, dark shows cancellation.',
+    'Three sine waves summed: one along x, one along y at 0.8x the frequency, one diagonal at 0.6x, each drifting at a different rate. Color maps the resulting amplitude — bright where the components reinforce, dark where they cancel. Superposition and nothing else, which is the point: interference underpins most of signal processing and takes three lines of arithmetic.',
   component: SimpleWaveBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
@@ -265,6 +265,10 @@ const SpectrogramOscilloscopeBackground: React.FC<
 
     // Fragment shader for spectrogram and oscilloscope visualization
     const fragmentShader = `
+      const float TWO_PI = 6.283185307179586;
+      // FM amount sliders run 0-1; scale them into a usable modulation index.
+      const float FM_INDEX_SCALE = 8.0;
+
       uniform float uTime;
       uniform vec2 uResolution;
       uniform vec2 uMouse;
@@ -442,13 +446,17 @@ const SpectrogramOscilloscopeBackground: React.FC<
       // Generate signal at specific time with effects chain
       float generateSignal(float t) {
         // === VCO GENERATION ===
-        // FM modulation for VCO1
-        float fm1 = sin(t * uVCO1FMFrequency) * uVCO1FMAmount;
-        float vco1Phase = t * (uVCO1Frequency * 0.01 + fm1) + uVCO1Phase;
+        // Frequency modulation, Chowning form: the modulator is added to the
+        // carrier's PHASE, not to its frequency before multiplying by t.
+        // Multiplying (fc + fm) by t makes the modulation depth grow without
+        // bound as t advances, which smears the sidebands instead of producing
+        // the fixed Bessel-series spectrum that defines FM synthesis.
+        // The amount sliders run 0-1 and are scaled to a useful modulation index.
+        float fm1 = sin(t * uVCO1FMFrequency) * uVCO1FMAmount * FM_INDEX_SCALE;
+        float vco1Phase = t * uVCO1Frequency * 0.01 + fm1 + uVCO1Phase;
 
-        // FM modulation for VCO2 with detune
-        float fm2 = sin(t * uVCO2FMFrequency) * uVCO2FMAmount;
-        float vco2Phase = t * (uVCO2Frequency * 0.01 * (1.0 + uDetune) + fm2) + uVCO2Phase;
+        float fm2 = sin(t * uVCO2FMFrequency) * uVCO2FMAmount * FM_INDEX_SCALE;
+        float vco2Phase = t * uVCO2Frequency * 0.01 * (1.0 + uDetune) + fm2 + uVCO2Phase;
 
         // Generate VCO signals
         float vco1 = generateWaveform(vco1Phase, uVCO1WaveformType) * uVCO1Amplitude;
@@ -513,107 +521,36 @@ const SpectrogramOscilloscopeBackground: React.FC<
         return signal;
       }
 
-      // Enhanced FFT magnitude calculation with better harmonic content
+      // Discrete Fourier transform of the actual generated signal at a single
+      // frequency bin.
+      //
+      // This deliberately measures rather than draws. The previous version
+      // correlated a few samples and then ADDED an idealised harmonic series,
+      // subharmonics, ring-mod sidebands and a noise floor on top -- so the
+      // spectrogram showed what the spectrum was assumed to look like, not what
+      // the signal contained. Every one of those features falls out of a
+      // correct transform anyway, because generateSignal genuinely produces
+      // them.
       float getFrequencyMagnitude(float freq, float time) {
-        float magnitude = 0.0;
-        float samples = 64.0;
+        float dt = 0.1; // Sample spacing; Nyquist is pi/dt in these units.
+        float re = 0.0;
+        float im = 0.0;
+        float windowSum = 0.0;
 
-        // Analyze a window of the signal
-        for(float i = 0.0; i < samples; i += 1.0) {
-          float t = time + i * 0.001;
-          float signal = generateSignal(t);
-
-          // Correlate with test frequency (both sine and cosine for better accuracy)
-          magnitude += signal * sin(freq * i * 0.1);
-          magnitude += signal * cos(freq * i * 0.1) * 0.5;
+        for (float i = 0.0; i < 64.0; i += 1.0) {
+          // A Hann window suppresses the spectral leakage a rectangular window
+          // would smear across every neighbouring bin.
+          float w = 0.5 - 0.5 * cos(TWO_PI * i / 63.0);
+          float s = generateSignal(time + i * dt) * w;
+          float phase = freq * i * dt;
+          re += s * cos(phase);
+          im += s * sin(phase);
+          windowSum += w;
         }
 
-        magnitude = abs(magnitude) / samples;
-
-        // Convert frequency to Hz for harmonic calculations
-        float freqHz = freq * 100.0;
-        float f1 = uVCO1Frequency;
-        float f2 = uVCO2Frequency * (1.0 + uDetune);
-
-        // Add fundamental frequencies with wider detection range
-        float dist1 = abs(freqHz - f1);
-        float dist2 = abs(freqHz - f2);
-
-        if (dist1 < 20.0) magnitude += uVCO1Amplitude * exp(-dist1 * 0.1);
-        if (dist2 < 20.0) magnitude += uVCO2Amplitude * exp(-dist2 * 0.1);
-
-        // Extended harmonics for richer spectrum (up to 20th harmonic)
-        for (float h = 2.0; h <= 20.0; h += 1.0) {
-          float hdist1 = abs(freqHz - f1 * h);
-          float hdist2 = abs(freqHz - f2 * h);
-
-          // Waveform-dependent harmonic amplitude
-          float harmAmp1 = 1.0 / pow(h, 0.7); // Slower rolloff
-          float harmAmp2 = 1.0 / pow(h, 0.7);
-
-          // Square waves have only odd harmonics with 1/n amplitude
-          if (uVCO1WaveformType > 0.5 && uVCO1WaveformType < 1.5) {
-            if (mod(h, 2.0) > 0.1) harmAmp1 *= 2.0 / h; // Strong odd harmonics
-            else harmAmp1 = 0.0;
-          }
-          // Sawtooth has all harmonics with 1/n amplitude
-          else if (uVCO1WaveformType > 2.5) {
-            harmAmp1 = 1.5 / h;
-          }
-          // Triangle has only odd harmonics with 1/n² amplitude
-          else if (uVCO1WaveformType > 1.5 && uVCO1WaveformType < 2.5) {
-            if (mod(h, 2.0) > 0.1) harmAmp1 = 0.8 / (h * h);
-            else harmAmp1 = 0.0;
-          }
-
-          // Same for VCO2
-          if (uVCO2WaveformType > 0.5 && uVCO2WaveformType < 1.5) {
-            if (mod(h, 2.0) > 0.1) harmAmp2 *= 2.0 / h;
-            else harmAmp2 = 0.0;
-          }
-          else if (uVCO2WaveformType > 2.5) {
-            harmAmp2 = 1.5 / h;
-          }
-          else if (uVCO2WaveformType > 1.5 && uVCO2WaveformType < 2.5) {
-            if (mod(h, 2.0) > 0.1) harmAmp2 = 0.8 / (h * h);
-            else harmAmp2 = 0.0;
-          }
-
-          if (hdist1 < 20.0) magnitude += uVCO1Amplitude * exp(-hdist1 * 0.03) * harmAmp1;
-          if (hdist2 < 20.0) magnitude += uVCO2Amplitude * exp(-hdist2 * 0.03) * harmAmp2;
-        }
-
-        // Add subharmonics for bass richness
-        for (float s = 2.0; s <= 4.0; s += 1.0) {
-          float sdist1 = abs(freqHz - f1 / s);
-          float sdist2 = abs(freqHz - f2 / s);
-          if (sdist1 < 10.0) magnitude += uVCO1Amplitude * exp(-sdist1 * 0.1) * 0.3;
-          if (sdist2 < 10.0) magnitude += uVCO2Amplitude * exp(-sdist2 * 0.1) * 0.3;
-        }
-
-        // Effects add frequency content
-        if (uDistortionAmount > 0.01) {
-          // Distortion adds high harmonics
-          for (float h = 3.0; h <= 10.0; h += 2.0) {
-            if (abs(freqHz - f1 * h) < 30.0) {
-              magnitude += uDistortionAmount * exp(-abs(freqHz - f1 * h) * 0.02) * 0.5;
-            }
-          }
-        }
-
-        if (uRingModAmount > 0.01) {
-          // Ring mod creates sidebands
-          float ringHz = uRingModFrequency;
-          magnitude += uRingModAmount * exp(-abs(freqHz - (f1 + ringHz)) * 0.05) * 0.4;
-          magnitude += uRingModAmount * exp(-abs(freqHz - abs(f1 - ringHz)) * 0.05) * 0.4;
-        }
-
-        if (uNoiseAmount > 0.01) {
-          // Noise adds broadband energy
-          magnitude += uNoiseAmount * 0.05 * (1.0 + hash(freqHz) * 0.3);
-        }
-
-        return magnitude;
+        // Normalise by the window's DC gain. The factor of two accounts for the
+        // energy in the negative-frequency image of a real-valued signal.
+        return 2.0 * sqrt(re * re + im * im) / max(1.0, windowSum);
       }
 
       // Color mapping for spectrogram using standardized colors

--- a/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
@@ -20,8 +20,6 @@ const SpectrogramOscilloscopeBackground: React.FC<
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const mouseRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
-  const spectrogramTextureRef = useRef<THREE.DataTexture | null>(null);
-  const waveformTextureRef = useRef<THREE.DataTexture | null>(null);
 
   // Web Audio API references
   const audioContextRef = useRef<AudioContext | null>(null);
@@ -225,34 +223,10 @@ const SpectrogramOscilloscopeBackground: React.FC<
     sceneRef.current = scene;
     rendererRef.current = renderer;
 
-    // Create textures for spectrogram history and waveform
-    const spectrogramWidth = 512; // Frequency bins
-    const spectrogramHeight = 256; // Time history
-    const spectrogramData = new Float32Array(
-      spectrogramWidth * spectrogramHeight * 4
-    );
-    const spectrogramTexture = new THREE.DataTexture(
-      spectrogramData,
-      spectrogramWidth,
-      spectrogramHeight,
-      THREE.RGBAFormat,
-      THREE.FloatType
-    );
-    spectrogramTexture.needsUpdate = true;
-    spectrogramTextureRef.current = spectrogramTexture;
-
-    // Waveform texture for current signal
-    const waveformSize = 1024;
-    const waveformData = new Float32Array(waveformSize * 4);
-    const waveformTexture = new THREE.DataTexture(
-      waveformData,
-      waveformSize,
-      1,
-      THREE.RGBAFormat,
-      THREE.FloatType
-    );
-    waveformTexture.needsUpdate = true;
-    waveformTextureRef.current = waveformTexture;
+    // The spectrogram is computed per fragment in the shader, so there is no
+    // history texture to maintain. An earlier texture-based approach left a
+    // 512x256 RGBA float buffer and a 1024-sample waveform buffer allocated
+    // and uploaded here; neither was ever sampled.
 
     // Vertex shader
     const vertexShader = `
@@ -268,13 +242,14 @@ const SpectrogramOscilloscopeBackground: React.FC<
       const float TWO_PI = 6.283185307179586;
       // FM amount sliders run 0-1; scale them into a usable modulation index.
       const float FM_INDEX_SCALE = 8.0;
+      // Upper bound for the analysis loop. Each step evaluates the full
+      // synthesis chain per fragment, so this is a framerate ceiling as much
+      // as a resolution one; the slider is capped to match.
+      const float MAX_FFT_WINDOW = 128.0;
 
       uniform float uTime;
       uniform vec2 uResolution;
       uniform vec2 uMouse;
-      uniform sampler2D uSpectrogramTexture;
-      uniform sampler2D uWaveformTexture;
-      uniform float uCurrentRow;
 
       // VCO 1 Parameters
       uniform float uVCO1Frequency;
@@ -332,6 +307,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
       uniform vec3 uColorMid;
       uniform vec3 uColorHigh;
       uniform vec3 uColorPeak;
+      uniform vec3 uColorGrid;
       uniform vec3 uWaveformColor;
       uniform float uWaveformThickness;
       uniform float uSpectrogramSmoothing;
@@ -533,14 +509,29 @@ const SpectrogramOscilloscopeBackground: React.FC<
       // them.
       float getFrequencyMagnitude(float freq, float time) {
         float dt = 0.1; // Sample spacing; Nyquist is pi/dt in these units.
+
+        // Window length trades frequency resolution against time resolution:
+        // a longer window resolves closely spaced partials but smears events
+        // that move. GLSL ES 1.0 requires a constant loop bound, so the loop
+        // is fixed at the maximum and exits early at the requested length.
+        float n = clamp(uFFTWindowSize, 16.0, MAX_FFT_WINDOW);
+
         float re = 0.0;
         float im = 0.0;
         float windowSum = 0.0;
 
-        for (float i = 0.0; i < 64.0; i += 1.0) {
-          // A Hann window suppresses the spectral leakage a rectangular window
-          // would smear across every neighbouring bin.
-          float w = 0.5 - 0.5 * cos(TWO_PI * i / 63.0);
+        for (float i = 0.0; i < MAX_FFT_WINDOW; i += 1.0) {
+          if (i >= n) break;
+
+          // The analysis window is blended from rectangular to Hann. A
+          // rectangular window gives the sharpest main lobe and the worst
+          // spectral leakage; Hann trades a wider main lobe for far lower
+          // sidelobes, which reads as a smoother spectrum. That blend *is*
+          // the smoothing control -- no post-hoc blurring involved.
+          float hann = 0.5 - 0.5 * cos(TWO_PI * i / (n - 1.0));
+          float w = mix(1.0, hann, uSpectrogramSmoothing);
+
+          // 'sample' is a reserved word in GLSL.
           float s = generateSignal(time + i * dt) * w;
           float phase = freq * i * dt;
           re += s * cos(phase);
@@ -548,8 +539,9 @@ const SpectrogramOscilloscopeBackground: React.FC<
           windowSum += w;
         }
 
-        // Normalise by the window's DC gain. The factor of two accounts for the
-        // energy in the negative-frequency image of a real-valued signal.
+        // Normalise by the window's DC gain so that changing window length or
+        // shape does not change the height of a peak. The factor of two
+        // accounts for the negative-frequency image of a real-valued signal.
         return 2.0 * sqrt(re * re + im * im) / max(1.0, windowSum);
       }
 
@@ -601,7 +593,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
           // Grid overlay for oscilloscope
           float gridX = smoothstep(0.003, 0.001, abs(fract(uv.x * 8.0) - 0.5));
           float gridY = smoothstep(0.003, 0.001, abs(fract(scopeY * 4.0) - 0.5));
-          finalColor += vec3(0.1, 0.15, 0.2) * max(gridX, gridY) * 0.25;
+          finalColor += uColorGrid * max(gridX, gridY) * 0.25;
 
         } else {
           // === SPECTROGRAM SECTION ===
@@ -623,13 +615,13 @@ const SpectrogramOscilloscopeBackground: React.FC<
             // Draw logarithmic frequency grid
             float octave = log(frequency * 100.0) / log(2.0);
             float octaveGrid = smoothstep(0.01, 0.001, abs(fract(octave) - 0.5));
-            finalColor += vec3(0.05, 0.1, 0.15) * octaveGrid * 0.4;
+            finalColor += uColorGrid * octaveGrid * 0.4;
 
             // Add markers at musical frequencies (A notes across octaves)
             for (float octaveA = 55.0; octaveA <= 3520.0; octaveA *= 2.0) {
               float markerPos = (log(octaveA) - logMin) / (logMax - logMin);
               if (abs(uv.x - markerPos) < 0.002) {
-                finalColor += vec3(0.1, 0.2, 0.3) * 0.5;
+                finalColor += uColorGrid * 1.4 * 0.5;
               }
             }
           } else {
@@ -638,7 +630,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
 
             // Frequency grid lines
             float freqGrid = smoothstep(0.003, 0.001, abs(fract(uv.x * 10.0) - 0.5));
-            finalColor += vec3(0.02, 0.05, 0.08) * freqGrid * 0.3;
+            finalColor += uColorGrid * 0.5 * freqGrid * 0.3;
           }
 
           // Get magnitude at this frequency and time
@@ -654,7 +646,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
 
           // Time grid lines
           float timeGrid = smoothstep(0.003, 0.001, abs(fract(spectrogramY * 10.0) - 0.5));
-          finalColor += vec3(0.02, 0.05, 0.08) * timeGrid * 0.2;
+          finalColor += uColorGrid * 0.5 * timeGrid * 0.2;
         }
 
         // Separator line between sections
@@ -699,9 +691,6 @@ const SpectrogramOscilloscopeBackground: React.FC<
             renderer.domElement.height / 2
           ),
         },
-        uSpectrogramTexture: { value: spectrogramTexture },
-        uWaveformTexture: { value: waveformTexture },
-        uCurrentRow: { value: 0.0 },
 
         // VCO 1 Parameters
         uVCO1Frequency: { value: settings.vco1Frequency },
@@ -759,6 +748,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
         uColorMid: { value: new THREE.Vector3(...settings.colors.primary) },
         uColorHigh: { value: new THREE.Vector3(...settings.colors.secondary) },
         uColorPeak: { value: new THREE.Vector3(...settings.colors.accent) },
+        uColorGrid: { value: new THREE.Vector3(...settings.colors.grid) },
         uWaveformColor: {
           value: new THREE.Vector3(...settings.colors.primary),
         },
@@ -816,7 +806,6 @@ const SpectrogramOscilloscopeBackground: React.FC<
     };
 
     // Animation loop
-    let currentRow = 0;
     const animate = (time: number) => {
       const t = time * 0.001;
 
@@ -831,10 +820,6 @@ const SpectrogramOscilloscopeBackground: React.FC<
       }
 
       // Update spectrogram texture row counter
-      currentRow = (currentRow + 1) % spectrogramHeight;
-      if (material.uniforms.uCurrentRow) {
-        material.uniforms.uCurrentRow.value = currentRow / spectrogramHeight;
-      }
 
       renderer.render(scene, camera);
       animationFrameRef.current = requestAnimationFrame(animate);
@@ -878,8 +863,6 @@ const SpectrogramOscilloscopeBackground: React.FC<
       geometry.dispose();
       material.dispose();
       renderer.dispose();
-      if (spectrogramTexture) spectrogramTexture.dispose();
-      if (waveformTexture) waveformTexture.dispose();
     };
   }, [settings, stableStartAudio, stableStopAudio]);
 

--- a/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/config.ts
@@ -601,7 +601,7 @@ export const spectrogramOscilloscopeConfig = createBackgroundConfig({
   id: 'spectrogram-oscilloscope',
   name: 'Dual FM Oscillator',
   description:
-    "Complete digital audio synthesizer demonstrating frequency modulation synthesis - a technique that creates complex harmonic content by having one oscillator modulate another's frequency. Two VCOs generate basic waveforms, then frequency modulate each other to produce rich timbres, passing through filters, delay, distortion, and reverb. Top display: oscilloscope showing waveform amplitude over time. Bottom: spectrogram showing frequency content evolution (low-to-high, left-to-right), with brightness indicating spectral intensity. Fundamental technique in electronic music production and audio DSP.",
+    "A working FM synthesizer. Two oscillators, one modulating the other's frequency — the trick that let a DX7 make a bell out of two sine waves while subtractive synths needed a filter bank. The signal then runs through filter, delay, distortion, and reverb. Top is an oscilloscope: amplitude against time. Bottom is a spectrogram: frequency low-to-high, scrolling left-to-right, brightness as intensity. Same signal in both domains at once, which is the fastest way to build intuition for what FM does to a spectrum. Hold the speaker button to hear it.",
   component: SpectrogramOscilloscopeBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/config.ts
+++ b/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/config.ts
@@ -167,6 +167,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 20,
     max: 2000,
     step: 10,
+    description:
+      'Pitch of the first oscillator in Hz. With FM off this is the lowest bright band on the spectrogram.',
     category: 'VCO 1',
   },
   {
@@ -176,6 +178,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'Level of the first oscillator going into the mixer.',
     category: 'VCO 1',
   },
   {
@@ -188,6 +191,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 2, label: 'Triangle' },
       { value: 3, label: 'Sawtooth' },
     ],
+    description:
+      'Waveform of the first oscillator, and the fastest way to see what harmonics are. A sine has a single partial; triangle and square have odd harmonics only; sawtooth has every harmonic. Watch bands appear on the spectrogram as you move through them.',
     category: 'VCO 1',
   },
   {
@@ -197,6 +202,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 6.28,
     step: 0.1,
+    description:
+      'Starting phase offset. On its own it is inaudible — it matters through how it lines up against the second oscillator.',
     category: 'VCO 1',
   },
   {
@@ -206,6 +213,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'Modulation index. Raise it and sidebands appear in pairs either side of the carrier, spaced at the FM frequency. That pair-spawning is the whole of FM synthesis, and it is why two oscillators can make a bell.',
     category: 'VCO 1',
   },
   {
@@ -215,6 +224,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.01,
     max: 10.0,
     step: 0.01,
+    description:
+      'Rate of the modulator, which sets how far apart the sidebands sit. Simple ratios against the carrier sound harmonic; irrational ones sound like metal.',
     category: 'VCO 1',
   },
 
@@ -226,6 +237,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 20,
     max: 2000,
     step: 10,
+    description:
+      'Pitch of the second oscillator in Hz. It defaults a fifth above the first.',
     category: 'VCO 2',
   },
   {
@@ -235,6 +248,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'Level of the second oscillator going into the mixer.',
     category: 'VCO 2',
   },
   {
@@ -247,6 +261,7 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 2, label: 'Triangle' },
       { value: 3, label: 'Sawtooth' },
     ],
+    description: 'Waveform of the second oscillator.',
     category: 'VCO 2',
   },
   {
@@ -256,6 +271,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 6.28,
     step: 0.1,
+    description:
+      'Starting phase offset for the second oscillator, relative to the first.',
     category: 'VCO 2',
   },
   {
@@ -265,6 +282,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'Modulation index for the second oscillator.',
     category: 'VCO 2',
   },
   {
@@ -274,6 +292,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.01,
     max: 10.0,
     step: 0.01,
+    description: 'Modulator rate for the second oscillator.',
     category: 'VCO 2',
   },
 
@@ -285,6 +304,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'Balance between the two oscillators — 0 is all VCO 1, 1 is all VCO 2.',
     category: 'Mixer',
   },
   {
@@ -294,6 +315,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: -0.1,
     max: 0.1,
     step: 0.001,
+    description:
+      'Offsets VCO 2 slightly from its nominal pitch. Small amounts produce slow beating as the two drift in and out of phase, which you can see as a pulsing in the oscilloscope trace.',
     category: 'Mixer',
   },
 
@@ -305,6 +328,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'How long the echo waits before repeating.',
     category: 'Delay/Echo',
   },
   {
@@ -314,6 +338,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 0.95,
     step: 0.05,
+    description:
+      'How much of the delayed signal is fed back in. High values repeat for a long time; near the top it barely decays at all.',
     category: 'Delay/Echo',
   },
   {
@@ -323,6 +349,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'Balance between the dry signal and the echo.',
     category: 'Delay/Echo',
   },
 
@@ -337,6 +364,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 2, label: 'Highpass' },
       { value: 3, label: 'Bandpass' },
     ],
+    description:
+      'Which frequencies survive. Lowpass keeps the bottom, highpass the top, bandpass a slice around the cutoff.',
     category: 'Filter',
   },
   {
@@ -346,6 +375,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.01,
     max: 0.99,
     step: 0.01,
+    description:
+      'The frequency the filter is centred on. Sweep it and watch the top of the spectrogram open and close.',
     category: 'Filter',
   },
   {
@@ -355,6 +386,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'Emphasis right at the cutoff. High settings make the filter ring at that frequency, and the peak shows up as a bright band that tracks the cutoff.',
     category: 'Filter',
   },
   {
@@ -364,6 +397,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 0.5,
     step: 0.01,
+    description: 'How far the cutoff is swept automatically.',
     category: 'Filter',
   },
   {
@@ -373,6 +407,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.01,
     max: 10.0,
     step: 0.01,
+    description: 'How fast that sweep runs.',
     category: 'Filter',
   },
 
@@ -384,6 +419,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'How hard the signal is driven. Distortion generates new harmonics above the ones already present, so the spectrogram fills in upward.',
     category: 'Distortion',
   },
   {
@@ -396,6 +433,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 2, label: 'Foldback' },
       { value: 3, label: 'Bitcrush' },
     ],
+    description:
+      'The shape of the non-linearity. Soft clipping adds harmonics gradually; the wave folder and bit crusher are far more aggressive and generate content that is not harmonically related at all.',
     category: 'Distortion',
   },
 
@@ -407,6 +446,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 10,
     max: 1000,
     step: 10,
+    description:
+      'Frequency of the modulating sine. Ring modulation produces sum and difference tones rather than harmonics, so you get two new bands either side rather than a series above.',
     category: 'Ring Mod',
   },
   {
@@ -416,6 +457,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'How much ring modulation is mixed in. Because the tones it produces are not harmonically related to the carrier, this is what makes a sound read as metallic or bell-like.',
     category: 'Ring Mod',
   },
 
@@ -427,6 +470,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'How much noise is mixed in. Noise is broadband, so it raises the whole spectrogram rather than adding bands.',
     category: 'Noise',
   },
   {
@@ -438,6 +483,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 1, label: 'Pink' },
       { value: 2, label: 'Brown' },
     ],
+    description:
+      'White noise has equal energy per hertz; pink falls off with frequency and sounds more natural; brown falls off faster still and sounds like distant rumble.',
     category: 'Noise',
   },
 
@@ -449,6 +496,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description: 'How much of the reverberated signal is mixed in.',
     category: 'Reverb',
   },
   {
@@ -458,6 +506,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 2.0,
     step: 0.1,
+    description: 'How long the reverb tail takes to fade.',
     category: 'Reverb',
   },
   {
@@ -467,6 +516,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 0.5,
     step: 0.01,
+    description:
+      'Gap between the dry sound and the onset of reverb. Longer predelay reads as a larger room.',
     category: 'Reverb',
   },
 
@@ -478,6 +529,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 2.0,
     step: 0.1,
+    description: 'Brightness of the oscilloscope trace along the top.',
     category: 'Visualization',
   },
   {
@@ -487,6 +539,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 2.0,
     step: 0.1,
+    description:
+      'Brightness of the spectrogram below. Raise it to bring out quiet partials, at the cost of washing out the loud ones.',
     category: 'Visualization',
   },
   {
@@ -496,6 +550,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.5,
     max: 3.0,
     step: 0.1,
+    description: 'Line weight of the oscilloscope trace.',
     category: 'Visualization',
   },
   {
@@ -505,6 +560,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.0,
     max: 1.0,
     step: 0.05,
+    description:
+      'Blends the analysis window from rectangular to Hann. Rectangular gives the sharpest peaks and the worst spectral leakage — energy smeared across neighbouring bins. Hann widens each peak slightly but suppresses the skirts around it, which reads as a cleaner spectrum. This is a real change to the transform, not a blur applied afterwards.',
     category: 'Visualization',
   },
   {
@@ -514,6 +571,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 1.0,
     max: 10.0,
     step: 0.5,
+    description:
+      'How much of the frequency range the linear scale covers. No effect when the logarithmic scale is selected.',
     category: 'Visualization',
   },
   {
@@ -523,6 +582,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 0.001,
     max: 1.0,
     step: 0.001,
+    description:
+      'How fast the spectrogram scrolls, which sets how much history is on screen.',
     category: 'Visualization',
   },
   {
@@ -530,8 +591,10 @@ const customSettingsSchema: SettingsSchema[] = [
     label: 'FFT Window Size',
     type: 'slider',
     min: 16,
-    max: 256,
+    max: 128,
     step: 16,
+    description:
+      'How many samples each analysis window covers. Longer windows resolve closely spaced partials but smear anything that moves — the time-versus-frequency tradeoff that every spectrogram has to pick a point on. Each sample evaluates the full synthesis chain, so this is also the main performance dial here.',
     category: 'Visualization',
   },
   {
@@ -542,6 +605,8 @@ const customSettingsSchema: SettingsSchema[] = [
       { value: 0, label: 'Linear' },
       { value: 1, label: 'Logarithmic' },
     ],
+    description:
+      'Logarithmic spacing gives each octave equal width, which matches how pitch is heard and keeps the bass legible. Linear spreads the high end out instead, which suits looking at harmonic series.',
     category: 'Visualization',
   },
   {
@@ -551,6 +616,7 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 10,
     max: 100,
     step: 5,
+    description: 'Lowest frequency shown on the logarithmic scale.',
     category: 'Visualization',
   },
   {
@@ -560,6 +626,8 @@ const customSettingsSchema: SettingsSchema[] = [
     min: 2000,
     max: 20000,
     step: 500,
+    description:
+      'Highest frequency shown. Most musical content sits below 5 kHz; above that you are mostly looking at the harmonics of the distortion.',
     category: 'Visualization',
   },
 
@@ -568,30 +636,36 @@ const customSettingsSchema: SettingsSchema[] = [
     key: 'colors.primary',
     label: 'Mid Amplitude Color',
     type: 'color',
+    description: 'Mid-level bins on the spectrogram.',
     category: 'Colors',
   },
   {
     key: 'colors.secondary',
     label: 'High Amplitude Color',
     type: 'color',
+    description: 'Loud bins.',
     category: 'Colors',
   },
   {
     key: 'colors.accent',
     label: 'Peak Amplitude Color',
     type: 'color',
+    description: 'The loudest bins — peaks.',
     category: 'Colors',
   },
   {
     key: 'colors.background',
     label: 'Low Amplitude Color',
     type: 'color',
+    description: 'Near-silent bins, and the canvas behind everything.',
     category: 'Colors',
   },
   {
     key: 'colors.grid',
     label: 'Grid Color',
     type: 'color',
+    description:
+      "The frequency, time and octave gridlines, and the oscilloscope's graticule.",
     category: 'Colors',
   },
 ];
@@ -601,7 +675,7 @@ export const spectrogramOscilloscopeConfig = createBackgroundConfig({
   id: 'spectrogram-oscilloscope',
   name: 'Dual FM Oscillator',
   description:
-    "A working FM synthesizer. Two oscillators, one modulating the other's frequency — the trick that let a DX7 make a bell out of two sine waves while subtractive synths needed a filter bank. The signal then runs through filter, delay, distortion, and reverb. Top is an oscilloscope: amplitude against time. Bottom is a spectrogram: frequency low-to-high, scrolling left-to-right, brightness as intensity. Same signal in both domains at once, which is the fastest way to build intuition for what FM does to a spectrum. Hold the speaker button to hear it.",
+    "A working FM synthesizer. Two oscillators, one modulating the other's phase — the trick that let a DX7 make a bell out of two sine waves while subtractive synths needed a filter bank. The signal then runs through filter, delay, distortion, and reverb. Top is an oscilloscope: amplitude against time. Bottom is a spectrogram: frequency low-to-high, scrolling left-to-right, brightness as intensity. Every spectrogram bin is a windowed DFT of the same samples the oscilloscope draws, so the sidebands, harmonic series and ring-mod tones are measured rather than drawn. Same signal in both domains at once, which is the fastest way to build intuition for what FM does to a spectrum. Hold the speaker button to hear it.",
   component: SpectrogramOscilloscopeBackground,
   customSettings: defaultCustomSettings,
   customSettingsSchema,

--- a/src/components/animated-backgrounds/core/standardSettings.ts
+++ b/src/components/animated-backgrounds/core/standardSettings.ts
@@ -20,6 +20,8 @@ export const standardSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 1.0,
     step: 0.05,
+    description:
+      'How strongly the background reads against the page. Lower it when the animation competes with text in front of it.',
     category: 'Visual',
   },
   {
@@ -29,6 +31,8 @@ export const standardSettingsSchema: SettingsSchema[] = [
     min: 0.005,
     max: 0.08,
     step: 0.002,
+    description:
+      'Base size for whatever the background draws — dots, cells, nodes. A rough zoom control.',
     category: 'Visual',
   },
 
@@ -40,6 +44,8 @@ export const standardSettingsSchema: SettingsSchema[] = [
     min: 0.1,
     max: 5.0,
     step: 0.1,
+    description:
+      'Master speed for the whole animation. Slow it right down to study what a background is doing rather than watch it.',
     category: 'Animation',
   },
 ];

--- a/src/components/animated-backgrounds/core/types.ts
+++ b/src/components/animated-backgrounds/core/types.ts
@@ -20,6 +20,12 @@ export interface SettingsSchema {
   step?: number;
   options?: { value: any; label: string }[];
   category: string;
+  /**
+   * What the control does and what to watch when you move it. Surfaced as a
+   * tooltip next to the label. Say what changes on screen, not what the
+   * variable is named.
+   */
+  description?: string;
 }
 
 // Props for animated background components

--- a/src/config/chat.ts
+++ b/src/config/chat.ts
@@ -122,7 +122,7 @@ export const chatConfig: ChatConfig = {
   },
   interface: {
     welcomeMessage:
-      "Hi! I'm chat, Alex's AI assistant running in your browser. Ask me about his experience, skills, education, or career background.",
+      "I'm chat, a small model running in your browser — no server, no API key. I only know what's in Alex's CV, so ask me about his experience, skills, or education.",
     placeholderText: {
       ready: 'ask about Alex...',
       loading: 'loading model...',

--- a/src/config/cv.ts
+++ b/src/config/cv.ts
@@ -129,7 +129,7 @@ export const cvData: CVData = {
         'Moved infrastructure to CloudFormation and CI/CD to GitHub Actions',
         'Added monitoring across the AI pipelines to catch quality regressions before customers did',
         'Built ontological models that gave the data model a consistent vocabulary to work from',
-        'Rewrote the hot query paths and indexing strategy as load grew',
+        'Restructured the Postgres schema as the access patterns became clear and load grew',
         'Coordinated with external development teams on platform integration, and ran project management out of GitHub',
       ],
       skills: [
@@ -153,7 +153,7 @@ export const cvData: CVData = {
         'Delivered a keynote on ChatGPT to a room of CIOs and founders',
         'Advised a blockchain unicorn on engineering process and operational flow',
         'Run technology assessments and build-versus-buy analysis for teams committing to an AI direction',
-        'Led migrations to AI-integrated systems where the cost case held up',
+        'Led migrations to AI-integrated systems, reducing cost and manual effort',
         'Consulted on personal knowledge management systems built around LLMs',
         'Help early-stage startups choose a technology stack they will not have to abandon in a year',
       ],
@@ -302,7 +302,7 @@ export const cvData: CVData = {
       achievements: [
         'Wrote production firmware for digital guitar pedals',
         'Shipped feature releases through a continuous integration process',
-        'Built the testing protocols that brought the bug rate down',
+        'Introduced testing practices to catch firmware defects before release',
         'Wrote the technical documentation and user manuals',
         'Fed customer feedback back into what got built next',
       ],

--- a/src/config/cv.ts
+++ b/src/config/cv.ts
@@ -4,9 +4,12 @@ export interface ExperienceItem {
   location: string;
   duration: string;
   description?: string;
+  /** Ordered strongest-first — the one-page resume takes the top `resume.maxBullets`. */
   achievements: string[];
   skills?: string[];
   highlights?: string[];
+  /** Omit to leave this role off the one-page resume entirely. */
+  resume?: { maxBullets: number };
 }
 
 export interface EducationItem {
@@ -78,28 +81,29 @@ export interface CVData {
 export const cvData: CVData = {
   personal: {
     name: 'Alex Nodeland',
-    title: 'Senior AI Engineer & Technical Consultant',
+    title: 'Senior AI Engineer',
     email: 'alex@ournature.studio',
     location: 'Upstate, New York, USA',
     website: 'alexnodeland.com',
     summary:
-      'Experienced engineer and mathematician with a strong background in high-performance computing, AI system design, and startup development. Proven track record in leading cross-functional teams and managing strategic business partnerships. Passionate about transforming complex ideas into user-friendly solutions, optimizing business processes, and driving innovation and growth.',
+      'Engineer and mathematician working on AI systems — agent orchestration, evaluation infrastructure, and the semantic models underneath — currently at Perch Insights. Previously co-founded and ran a supercomputing startup in Singapore for four years, led engineering at a music-ML company acquired by SoundCloud, and researched audio compression on HPC clusters at Stony Brook. Most useful on problems that sit between mathematics and production systems.',
   },
 
   experience: [
     {
       title: 'Senior AI Engineer',
       company: 'Perch Insights',
+      resume: { maxBullets: 3 },
       location: 'Remote, NY',
       duration: '2024 - Present',
       achievements: [
-        'Led AI engineering initiatives that transformed data analysis workflows, enabling business analysts to perform previously impossible automated insights and drastically reducing time-to-insight',
-        'Architected and implemented a DAG-based workflow orchestration framework that enables autonomous AI agents to perform complex multi-step data analysis',
-        'Designed a domain-specific language (DSL) that allows non-technical users to construct sophisticated analysis workflows combining LLM agents with traditional ML models',
-        'Built self-improving AI systems through virtuous feedback loops that automatically capture user feedback, expand evaluation datasets, and power few-shot examples downstream',
-        'Developed tabular insight generator agents using Jinja templating that maintain complete data lineage and provenance tracking, ensuring full auditability for enterprise compliance requirements',
-        'Enhanced the semantic data model with ontological abstractions and higher-order business concepts, enabling automated root cause analysis and data discovery',
-        'Engineered a fault-tolerant distributed worker architecture on AWS (ECS/SNS/SQS) with dead letter queue management and zero-downtime deployments',
+        'Built a DAG-based orchestration framework that lets autonomous agents carry out multi-step data analysis end to end',
+        'Designed a DSL that non-technical users write analysis workflows in, mixing LLM agents with conventional ML models in the same pipeline',
+        'Extended the semantic data model with ontological abstractions and higher-order business concepts — the layer that makes automated root-cause analysis and data discovery possible at all',
+        'Built the feedback loop that turns user corrections into evaluation data and downstream few-shot examples, so the system improves without a retraining cycle',
+        'Wrote tabular insight agents on Jinja templates that carry full lineage and provenance, so any generated number can be traced back to source for enterprise audit',
+        'Ran a fault-tolerant distributed worker fleet on AWS (ECS/SNS/SQS) with dead-letter queue handling and zero-downtime deploys',
+        'Lead AI engineering for the analytics product, turning analyst workflows that were manual or simply not possible into automated ones',
       ],
       skills: [
         'Python',
@@ -114,20 +118,19 @@ export const cvData: CVData = {
     {
       title: 'Head of AI',
       company: 'Influize',
+      resume: { maxBullets: 3 },
       location: 'Remote, NY',
       duration: '2023 - 2024',
       achievements: [
-        'Pioneered the AI engineering department, developing fully functional AI systems from conceptual models',
-        "Developed and fully implemented RAG-based LLM systems, enhancing the product's capabilities in generating dynamic responses based on retrieved data",
-        'Enhanced data model clarity by developing ontological models',
-        'Improved database security and efficiency by designing and implementing schema and backend infrastructure using Supabase Postgres',
-        'Boosted system security and functionality by building scalable AI pipelines with robust authentication',
-        'Optimized AI pipeline performance by implementing monitoring systems',
-        'Enhanced API throughput and reduced latency by architecting a high-performance, scalable API interface tailored for AI pipeline integrations',
-        'Optimized deployment workflows and enhanced system reliability by adopting Infrastructure as Code (IaC) practices using AWS CloudFormation and setting up a robust CI/CD pipeline with GitHub Actions',
-        'Ensured seamless platform integration by collaborating with external development teams',
-        "Streamlined development and coordination by directing project management with GitHub's self-management system",
-        'Boosted system responsiveness by optimizing database performance for higher scale and efficiency',
+        'Started the AI function from nothing and shipped its first systems to production',
+        "Built the RAG pipeline behind the product's generated responses, covering retrieval, chunking, and grounding",
+        'Designed the Postgres schema and backend on Supabase, including authentication and access control',
+        'Architected the API layer the AI pipelines sit behind, which cut latency and raised throughput',
+        'Moved infrastructure to CloudFormation and CI/CD to GitHub Actions',
+        'Added monitoring across the AI pipelines to catch quality regressions before customers did',
+        'Built ontological models that gave the data model a consistent vocabulary to work from',
+        'Rewrote the hot query paths and indexing strategy as load grew',
+        'Coordinated with external development teams on platform integration, and ran project management out of GitHub',
       ],
       skills: [
         'Python',
@@ -142,17 +145,17 @@ export const cvData: CVData = {
     {
       title: 'Technical Strategy Consultant',
       company: 'Freelance',
+      resume: { maxBullets: 2 },
       location: 'Remote, NY',
       duration: '2022 - Present',
       achievements: [
-        'Enhanced operational flow by providing strategic guidance to a blockchain unicorn',
-        'Showcased AI potential by delivering a keynote talk on ChatGPT to CIOs and founders',
-        'Improved personal knowledge management systems by advising on AI and LLM utilization',
-        'Developed strategic plans to keep companies at the forefront of technology',
-        'Reduced costs and increased efficiency by facilitating transitions to AI-integrated systems',
-        'Advanced business processes by engaging in AI research and development',
-        'Identified AI solution opportunities through comprehensive market analysis',
-        'Supported startups in technology selection and strategic decision-making',
+        'Advise startups and established companies on where AI belongs in their stack, and where it does not',
+        'Delivered a keynote on ChatGPT to a room of CIOs and founders',
+        'Advised a blockchain unicorn on engineering process and operational flow',
+        'Run technology assessments and build-versus-buy analysis for teams committing to an AI direction',
+        'Led migrations to AI-integrated systems where the cost case held up',
+        'Consulted on personal knowledge management systems built around LLMs',
+        'Help early-stage startups choose a technology stack they will not have to abandon in a year',
       ],
       skills: [
         'Strategic Planning',
@@ -164,19 +167,17 @@ export const cvData: CVData = {
     {
       title: 'Tech Lead',
       company: 'Musiio (acquired by SoundCloud)',
+      resume: { maxBullets: 2 },
       location: 'Singapore',
       duration: '2021 - 2022',
       achievements: [
-        'Led a cross-functional team, fostering collaboration with the music team and external partners',
-        'Streamlined development workflows, managing scheduling and coordination with research and sales teams',
-        'Fostered continuous improvement by conducting operational analysis and organizing training sessions',
-        'Mentored team members, supporting career development and engagement',
-        'Ensured effective project management by collaborating with founders on development plans',
-        'Guided technical development, meeting customer and partner requirements',
-        'Managed GCP infrastructure, implementing Kubernetes & Istio and monitoring with Grafana & Prometheus',
-        'Revamped CI/CD process with Jenkins and Cypress, ensuring software quality',
-        'Introduced agile practices (Scrum) to streamline operations and increase productivity',
-        'Improved efficiency by implementing workflow automation and building a custom data ingestion pipeline',
+        'Led a cross-functional engineering team, working alongside the music, research, and sales sides of the company',
+        'Ran GCP infrastructure: Kubernetes and Istio, monitored with Grafana and Prometheus',
+        'Rebuilt CI/CD on Jenkins with Cypress end-to-end coverage',
+        'Built a custom data ingestion pipeline and automated the manual steps that had grown around it',
+        'Introduced Scrum, along with the scheduling and coordination practice needed to make it stick',
+        'Set technical direction against customer and partner requirements, planning releases with the founders',
+        'Mentored engineers on the team and ran training sessions off the back of operational reviews',
       ],
       skills: [
         'Python',
@@ -192,22 +193,18 @@ export const cvData: CVData = {
     {
       title: 'CEO & Co-Founder',
       company: 'Archanan',
+      resume: { maxBullets: 3 },
       location: 'Singapore, SG',
       duration: '2018 - 2022',
       achievements: [
-        'Drove strategic direction by formulating business models and go-to-market strategies',
-        'Provided critical business insights by devising dynamic financial projections',
-        'Ensured seamless workflows by integrating management systems',
-        'Solidified financial foundation by securing early rounds of funding from government, VC, and angel investors',
-        'Expanded client base by attracting early customers, including Fortune 500 companies and national governments',
-        'Brought products to market by spearheading product development from conceptualization to launch',
-        'Fostered rapid growth by expanding the team from 3 to 15 in the first year',
-        'Strengthened partnerships by managing diplomatic relations with multiple levels of government',
-        'Promoted customer loyalty by establishing a strong brand identity',
-        'Secured beneficial terms by negotiating contracts and agreements with partners and suppliers',
-        'Mitigated business risks by implementing risk management strategies',
-        'Maintained transparency by steering investor relations and board communications',
-        'Challenged traditional norms by leveraging technical background to drive innovative solutions',
+        'Took the product from concept to launch: a cloud platform that emulates supercomputer environments so teams can develop and test at scale without waiting for time on the real machine',
+        'Raised early rounds from government, VC, and angel investors',
+        'Won early customers including Fortune 500 companies and national governments',
+        'Grew the team from 3 to 15 in the first year',
+        'Set the business model and go-to-market strategy, with the financial model underneath it',
+        'Managed relationships with several levels of government across the region',
+        'Ran investor relations and board communications',
+        'Negotiated the contracts with partners and suppliers',
       ],
       skills: [
         'Leadership',
@@ -223,15 +220,12 @@ export const cvData: CVData = {
       location: 'Singapore, SG',
       duration: 'Jan 2018 - Jun 2018',
       achievements: [
-        'Optimized market fit by refining early-stage ideas',
-        'Validated business concepts through comprehensive market research',
-        'Catalyzed product development by securing early LOIs and bringing MVPs to fruition',
-        'Drove business growth by formulating and implementing go-to-market strategies',
-        'Provided key insights through financial modeling to plan and predict business performance',
-        'Initiated a successful venture by co-founding Archanan',
-        'Secured seed capital by leading fundraising efforts',
-        'Broadened network and resources by forming strategic partnerships',
-        'Strengthened market positioning through business development initiatives',
+        'Co-founded Archanan out of the programme',
+        'Secured letters of intent from early customers before committing to a build',
+        'Tested several ideas against the market and killed the ones that did not hold up',
+        'Built the financial model and the go-to-market plan that came out of it',
+        'Led the first fundraise',
+        'Formed the early partnerships the company ran on',
       ],
       skills: [
         'Entrepreneurship',
@@ -243,19 +237,16 @@ export const cvData: CVData = {
     {
       title: 'CTO, Chief Mathematician',
       company: 'Scala Computing',
+      resume: { maxBullets: 2 },
       location: 'New York, NY',
       duration: '2016 - 2017',
       achievements: [
-        'Drove financial stability by securing seed capital from prominent VCs and angels',
-        'Elevated company status by gaining membership to the Grand Central Tech Accelerator',
-        'Fast-tracked product development by designing, architecting, and implementing MVPs',
-        'Ensured reliable software solutions by developing, testing, and integrating production code',
-        'Enhanced productivity and collaboration by establishing robust development processes',
-        'Improved software performance by leading a team of developers in delivering cloud middleware solutions',
-        'Advanced technological capabilities by directing algorithm development for complex problems',
-        'Ensured software quality by establishing strict QA standards',
-        'Minimized bugs through efficient code review practices',
-        'Enhanced client service offerings by cultivating strong client relationships',
+        'Designed and built the MVPs, then the production cloud middleware that replaced them',
+        'Directed algorithm development for the core computational problems the product depended on',
+        'Raised seed capital from VCs and angels',
+        'Led the engineering team and set the code review and QA standards it worked to',
+        'Got the company into the Grand Central Tech accelerator',
+        'Worked directly with clients on what to build next',
       ],
       skills: [
         'Mathematics',
@@ -271,12 +262,10 @@ export const cvData: CVData = {
       location: 'Stony Brook, NY',
       duration: '2016 - 2017',
       achievements: [
-        'Pioneered sound technology by designing, prototyping, and testing audio synthesizers',
-        'Contributed to novel audio technologies by engineering unique circuit designs',
-        'Generated creative content using academic research',
-        'Demystified complex concepts through collaboration with music technology industry professionals',
-        'Inspired creativity by leading seminars on the intersection of music and mathematics',
-        'Facilitated collaborative opportunities by networking with industry professionals',
+        'Designed, prototyped, and tested audio synthesizers, including the circuit design',
+        'Led seminars on where music and mathematics meet',
+        'Turned research into work that could actually be performed and heard',
+        'Collaborated with people from the music technology industry on novel audio hardware',
       ],
       skills: [
         'Audio Engineering',
@@ -292,11 +281,10 @@ export const cvData: CVData = {
       location: 'Stony Brook, NY',
       duration: '2016 - 2017',
       achievements: [
-        'Boosted research capabilities by spearheading a supercomputing project funded by the High Performance Computing Consortium of New York',
-        'Contributed to advancements in audio technology by conducting in-depth research on optimal wavelet bases for audio compression',
-        'Provided insights into spectrum trends by performing real-time signal analysis',
-        'Ensured up-to-date practices by liaising with other research teams',
-        'Maintained reliable data sources by organizing and maintaining project documentation',
+        'Researched optimal wavelet bases for audio compression, searching for a general procedure rather than a one-off basis',
+        'Ran a supercomputing project funded by the High Performance Computing Consortium of New York',
+        'Performed real-time signal analysis on spectrum data',
+        'Kept the project documentation and datasets in a state other researchers could pick up',
       ],
       skills: [
         'Research',
@@ -312,12 +300,11 @@ export const cvData: CVData = {
       location: 'Port Jefferson, NY',
       duration: '2014 - 2015',
       achievements: [
-        'Enhanced product functionality by developing production-grade firmware for digital guitar pedals',
-        'Ensured regular product improvements by contributing to continuous integration and feature releases',
-        'Simplified customer usage by authoring technical documentation and user manuals',
-        'Improved product quality by optimizing processes to reduce software bugs',
-        'Integrated customer feedback into product development',
-        'Ensured software quality by implementing rigorous testing protocols',
+        'Wrote production firmware for digital guitar pedals',
+        'Shipped feature releases through a continuous integration process',
+        'Built the testing protocols that brought the bug rate down',
+        'Wrote the technical documentation and user manuals',
+        'Fed customer feedback back into what got built next',
       ],
       skills: [
         'Firmware Development',
@@ -332,13 +319,10 @@ export const cvData: CVData = {
       location: 'Port Jefferson, NY',
       duration: '2010 - 2014',
       achievements: [
-        'Contributed to product manufacturing by assembling printed circuit boards for audio processing units',
-        'Guaranteed product reliability by conducting rigorous hardware testing',
-        'Ensured customer satisfaction by managing servicing of customer hardware',
-        'Maintained high service standards by leading technical customer service efforts',
-        'Optimized production processes through continuous improvement initiatives',
-        'Ensured quality standards by providing training to new staff',
-        'Contributed to customer service excellence by handling returns and repairs',
+        'Assembled and tested printed circuit boards for audio processing units',
+        'Ran technical customer service, including repairs and returns',
+        'Serviced customer hardware sent back to the shop',
+        'Trained new staff on assembly and quality control',
       ],
       skills: [
         'Hardware Assembly',
@@ -355,8 +339,7 @@ export const cvData: CVData = {
       institution: 'Stony Brook University',
       location: 'Stony Brook, NY',
       duration: '2016 - (Incomplete)',
-      description:
-        'Engaged in preliminary research but transitioned to entrepreneurial roles prior to advancing to candidacy.',
+      description: 'Left before advancing to candidacy to start a company.',
       relevantCoursework: [
         'Numerical Analysis',
         'Numerical Partial Differential Equations',
@@ -367,7 +350,7 @@ export const cvData: CVData = {
         'Parallel Computing',
       ],
       achievements: [
-        'Applied research experience at the Center of Excellence in Wireless Information Technology (CEWIT) and SUNY Research Foundation, focusing on audio compression and signal analysis',
+        'Research at the Center of Excellence in Wireless Information Technology (CEWIT) and the SUNY Research Foundation, on audio compression and signal analysis',
       ],
     },
     {
@@ -447,3 +430,28 @@ export const cvData: CVData = {
     languages: ['English (Native)'],
   },
 };
+
+/**
+ * Derives the one-page resume from the full CV.
+ *
+ * `cvData` stays the single source of truth: a role appears on the resume only
+ * if it carries a `resume` field, and contributes the first `maxBullets` of its
+ * achievements — which is why achievements are ordered strongest-first.
+ * Coursework and certifications are dropped to make the page fit.
+ */
+export const getResumeData = (data: CVData = cvData): CVData => ({
+  ...data,
+  experience: data.experience
+    .filter(role => role.resume)
+    .map(role => ({
+      ...role,
+      achievements: role.achievements.slice(0, role.resume!.maxBullets),
+    })),
+  education: data.education.map(
+    ({ relevantCoursework: _omit, ...rest }) => rest
+  ),
+  certifications: [],
+});
+
+/** The one-page resume, derived from `cvData` at module load. */
+export const resumeData: CVData = getResumeData();

--- a/src/config/homepage.ts
+++ b/src/config/homepage.ts
@@ -36,68 +36,68 @@ export interface HomepageConfig {
 export const homepageConfig: HomepageConfig = {
   hero: {
     title: 'alex nodeland',
-    subtitle: 'systems thinker // creative technologist',
+    subtitle: 'math → audio dsp → distributed systems → ai',
   },
   about: {
     paragraphs: [
-      "i transform complex challenges into elegant solutions. whether it's orchestrating ai systems, architecting cloud infrastructure, or bridging technical and creative domains, i bring deep expertise across the full technology stack.",
-      "from startup cto to ai engineering lead, i've spent years turning ambitious ideas into production-ready systems that actually deliver value. currently focused on ai engineering, devops automation, and innovative technical projects.",
-      "ready to solve your toughest technical challenges? let's build something remarkable together.",
+      'i build ai systems, mostly the parts nobody demos: agent orchestration, evaluation loops, and the semantic layer underneath that has to be right before any of it works. currently senior ai engineer at perch insights.',
+      'before that i co-founded archanan in singapore and ran it as ceo for four years — we built cloud emulators of supercomputers so people could develop at scale without waiting in a queue. then led engineering at musiio, a music-ml company soundcloud later acquired. earlier still: wavelet bases for audio compression at stony brook, and firmware for guitar pedals before that.',
+      'i write rust on weekends, mostly audio synthesis and probabilistic programming. the backgrounds on this site are live simulations rather than video — the gear icon opens their controls.',
     ],
   },
   consulting: {
-    title: "let's build something",
+    title: 'consulting',
     description:
-      "stuck on a complex technical challenge? from ai system architecture to strategic technology decisions, i help organizations cut through complexity and build solutions that actually work. whether you need hands-on engineering or strategic guidance, we'll turn your biggest obstacles into competitive advantages.",
+      "i take on a few engagements a year. usually it's a team whose llm prototype works in a demo and falls over in production, and the fix is almost never the model — it's the data model, the evals, or the failure handling. sometimes the question is earlier than that: what to build, or whether to.",
     ctaButtons: {
       primary: {
-        text: 'discuss your challenge',
+        text: 'send me an email',
         action: 'email',
       },
       secondary: {
-        text: 'schedule a strategy call',
+        text: 'book a call',
         action: 'calendar',
       },
     },
   },
   expertise: {
-    title: 'how i can help',
+    title: 'what i work on',
     items: [
       {
         icon: '🤖',
-        title: 'ai system architecture',
+        title: 'ai systems',
         description:
-          'llm orchestration, rag systems, and autonomous ai agent workflows that scale',
+          'agent orchestration, rag, tool use, and the failure modes that only appear under real traffic',
       },
       {
         icon: '⚙️',
-        title: 'cloud & devops',
+        title: 'infrastructure',
         description:
-          'aws, kubernetes, infrastructure as code, and reliable deployment pipelines',
+          'aws, kubernetes, infrastructure as code, and deploy pipelines that nobody has to babysit',
+      },
+      {
+        icon: '📊',
+        title: 'data engineering',
+        description:
+          'pipelines, semantic models, and lineage you can actually audit after the fact',
+      },
+      {
+        icon: '🔍',
+        title: 'evaluation & observability',
+        description:
+          'eval sets, feedback loops, and catching a regression before a customer does',
       },
       {
         icon: '🧠',
         title: 'technical strategy',
         description:
-          'system design, technology assessment, and strategic technical decision-making',
+          'architecture review, build-vs-buy, and deciding which half of the roadmap to cut',
       },
       {
-        icon: '🔧',
-        title: 'full-stack engineering',
-        description:
-          'from databases to frontends, building complete solutions that work',
-      },
-      {
-        icon: '🎨',
+        icon: '🎛️',
         title: 'creative technology',
         description:
-          'bridging art and engineering, from audio processing to interactive systems',
-      },
-      {
-        icon: '🚀',
-        title: 'startup & product leadership',
-        description:
-          'from concept to launch, building teams and products that deliver real value',
+          'audio dsp, synthesis, generative visuals — the part i would do for free anyway',
       },
     ],
   },

--- a/src/config/homepage.ts
+++ b/src/config/homepage.ts
@@ -48,7 +48,7 @@ export const homepageConfig: HomepageConfig = {
   consulting: {
     title: 'consulting',
     description:
-      "i take on a few engagements a year. usually it's a team whose llm prototype works in a demo and falls over in production, and the fix is almost never the model — it's the data model, the evals, or the failure handling. sometimes the question is earlier than that: what to build, or whether to.",
+      "i take on a few engagements a year, split about evenly between two things. sometimes it's an llm prototype that works in a demo and falls over in production, where the fix is almost never the model — it's the data model, the evals, or the failure handling. sometimes it's the earlier question of what to build with ai, or whether to.",
     ctaButtons: {
       primary: {
         text: 'send me an email',

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -58,7 +58,7 @@ export const siteConfig: SiteConfig = {
   siteName: 'alex nodeland',
   siteUrl: 'https://alexnodeland.com',
   description:
-    'senior ai engineer & technical consultant specializing in ai system architecture, devops automation, and production-ready ai infrastructure.',
+    'ai engineer and mathematician. agent systems, distributed infrastructure, and audio dsp. previously ceo of a supercomputing startup.',
   author: 'alex nodeland',
 
   // Contact information
@@ -83,7 +83,7 @@ export const siteConfig: SiteConfig = {
   seo: {
     defaultTitle: 'alex nodeland',
     defaultDescription:
-      'senior ai engineer & technical consultant specializing in ai system architecture, devops automation, and production-ready ai infrastructure.',
+      'ai engineer and mathematician. agent systems, distributed infrastructure, and audio dsp. previously ceo of a supercomputing startup.',
     defaultImage: '/images/icon.png',
   },
 

--- a/src/content/blog/151111_future-of-sound.md
+++ b/src/content/blog/151111_future-of-sound.md
@@ -11,7 +11,7 @@ two of them made the article. a bass synthesizer that tracks the pitch of whatev
 
 i had been building audio hardware at pigtronix on long island for a few years by then, so the pedals were not hypothetical. what was new was putting a learning system in the loop: something that proposes a sound, watches which ones you keep, and gets better at proposing.
 
-this was the motiff technologies era — my first company, run out of an undergraduate degree with pigtronix advising. it did not become archanan or anything else, but it is where i learned that shipping hardware and having a good idea are unrelated skills.
+this was the motiff technologies era — my first company, run out of an undergraduate degree with pigtronix advising.
 
 the line i gave the reporter still holds up. music is data processing — it is just data processing where the error metric is whether it sounds good, which is the hard part.
 

--- a/src/content/blog/151111_future-of-sound.md
+++ b/src/content/blog/151111_future-of-sound.md
@@ -1,10 +1,18 @@
 ---
 title: 'The Future of Sound'
 date: '2015-11-11'
-description: 'Article exploring emerging trends in audio technology'
+description: 'The Stony Brook Press on the intelligent synthesizers I was building as an undergraduate — pitch-tracking bass synthesis and convolution reverb.'
 category: 'Press'
 ---
 
-I was featured in The Stony Brook Press back in 2015 discussing my work on intelligent audio processing and synthesizer technology. The article explores how I'm combining mathematics, music, and machine learning to create devices that can understand and respond to musicians in real time - from bass synthesizers that automatically calculate harmonically correct lower pitches to convolution reverbs that can digitally recreate any acoustic space. It also covers my company Motiff Technologies and the broader implications of this work beyond music.
+the stony brook press came to talk to me about synthesizers that listen back. i was twenty and halfway through an applied maths degree, building pedals that tried to work out what a player was doing rather than waiting to be told.
 
-[Read the full article](https://sbpress.com/2015/11/the-future-of-sound/)
+two of them made the article. a bass synthesizer that tracks the pitch of whatever it hears and calculates the harmonically correct lower note in real time, so it stays in key and in time without being configured. and a convolution reverb, which takes an impulse response of a room and lets you play as though you were standing in it — carnegie hall, or the basement venue down the road, from a recording of the space.
+
+i had been building audio hardware at pigtronix on long island for a few years by then, so the pedals were not hypothetical. what was new was putting a learning system in the loop: something that proposes a sound, watches which ones you keep, and gets better at proposing.
+
+this was the motiff technologies era — my first company, run out of an undergraduate degree with pigtronix advising. it did not become archanan or anything else, but it is where i learned that shipping hardware and having a good idea are unrelated skills.
+
+the line i gave the reporter still holds up. music is data processing — it is just data processing where the error metric is whether it sounds good, which is the hard part.
+
+[read the full article](https://sbpress.com/2015/11/the-future-of-sound/)

--- a/src/content/blog/160201_hpc-audio-research.md
+++ b/src/content/blog/160201_hpc-audio-research.md
@@ -1,10 +1,14 @@
 ---
 title: 'Supercomputers For Audio Research and Development'
 date: '2016-02-01'
-description: 'Profile piece on using supercomputers for audio research'
+description: "CEWIT's newsletter on my use of Stony Brook's supercomputing time for audio synthesis and modelling."
 category: 'Press'
 ---
 
-This profile piece from Stony Brook University's CEWIT newsletter features my work applying supercomputing resources to develop audio synthesis and modeling technologies. The research explores how high-performance computing can transform audio processing for applications ranging from musical instruments to forensic analysis and medical applications.
+cewit's newsletter ran a short piece on what i was doing with the university's supercomputing allocation: audio synthesis and modelling at a scale that does not fit on a desktop.
 
-[Read the full article](https://www.cewit.org/programs/_documents/CEWITNewsletter_FEB2016.pdf)
+the useful thing about having that much compute is that it changes which questions you are allowed to ask. a lot of audio engineering is choosing a filter design or a basis function on the strength of experience and then tuning it until it sounds right. with a cluster you can search the space instead — evaluate thousands of candidates against a real corpus and find out whether the conventional choice was ever the best one.
+
+the same models turn up well outside music. forensic audio and medical imaging are both, underneath, the problem of pulling a signal out of noise when you have a decent prior about what the signal should look like.
+
+[read the full article](https://www.cewit.org/programs/_documents/CEWITNewsletter_FEB2016.pdf) — it is inside the february 2016 newsletter pdf.

--- a/src/content/blog/161101_optimal-wavelet-bases.md
+++ b/src/content/blog/161101_optimal-wavelet-bases.md
@@ -1,10 +1,14 @@
 ---
 title: 'Optimal Wavelet Bases For Audio Compression'
 date: '2016-11-01'
-description: 'Research publication on wavelet-based audio compression techniques'
+description: 'Searching for a general procedure to pick the best wavelet basis for a class of audio, rather than choosing one by taste. Run on the IACS supercomputers.'
 category: 'Press'
 ---
 
-Through experimentation and analysis using IACS supercomputers, I'm working to uncover a common procedure for finding optimal wavelet bases that can efficiently compress audio data with minimal loss, building on the success of implementations like JPEG 2000.
+jpeg 2000 swapped the discrete cosine transform for wavelets and got visibly better images at the same bitrate, with none of the block artefacts that give away ordinary jpeg. the obvious question is why the same move is not standard for audio.
 
-[Read the full article](https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf)
+part of the answer is that nobody agrees on which wavelet to use. unlike the dct, which is one fixed transform, "wavelet" is a family — and the right member depends on the signal you are compressing. in practice people pick one that has worked before and tune around it.
+
+this research was an attempt at a procedure for finding the optimal basis for a given class of audio rather than choosing by taste: define what optimal means for a signal class, then search the space of admissible bases against a real corpus. the searching is the part that needs the iacs supercomputers. the criterion is the part that needs the mathematics, and it is the harder half — a basis that minimises reconstruction error is not necessarily the one that sounds best, because the ear does not weight error uniformly.
+
+[read the full article](https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf) — it is inside the november 2016 newsletter pdf.

--- a/src/content/blog/161101_optimal-wavelet-bases.md
+++ b/src/content/blog/161101_optimal-wavelet-bases.md
@@ -9,6 +9,6 @@ jpeg 2000 swapped the discrete cosine transform for wavelets and got visibly bet
 
 part of the answer is that nobody agrees on which wavelet to use. unlike the dct, which is one fixed transform, "wavelet" is a family — and the right member depends on the signal you are compressing. in practice people pick one that has worked before and tune around it.
 
-this research was an attempt at a procedure for finding the optimal basis for a given class of audio rather than choosing by taste: define what optimal means for a signal class, then search the space of admissible bases against a real corpus. the searching is the part that needs the iacs supercomputers. the criterion is the part that needs the mathematics, and it is the harder half — a basis that minimises reconstruction error is not necessarily the one that sounds best, because the ear does not weight error uniformly.
+this research was an attempt at a procedure for finding the optimal basis for a given class of audio rather than choosing by taste: define what optimal means for a signal class, then search the space of admissible bases against a real corpus. the searching is the part that needs the iacs supercomputers. the criterion is the part that needs the mathematics.
 
 [read the full article](https://www.cewit.org/programs/_documents/CEWITNewsletter_NOV2016.pdf) — it is inside the november 2016 newsletter pdf.

--- a/src/content/blog/190301_hpc-accessibility.md
+++ b/src/content/blog/190301_hpc-accessibility.md
@@ -1,10 +1,14 @@
 ---
 title: "Supercomputing Shouldn't Be Rocket Science"
 date: '2019-03-01'
-description: 'Opinion piece on making supercomputing more accessible'
+description: 'A piece for Asian Scientist arguing that the hard part of supercomputing is not the computing — it is the gap between a working laptop simulation and code that survives at scale.'
 category: 'Press'
 ---
 
-As cofounder and CEO of Archanan, I believe the future of HPC lies in cloud-based accessibility where researchers can focus on their science rather than wrestling with complex system architectures. This article explores how we're working to bridge the gap between traditional desktop development and multi-million-dollar supercomputer deployment, making high-performance computing truly accessible to scientists worldwide.
+a piece for asian scientist, written while running archanan, arguing that the hard part of supercomputing is not the computing.
 
-[Read the full article](https://www.asianscientist.com/2019/03/features/supercomputing-shouldnt-be-rocket-science/)
+picture a researcher with a simulation that works on their laptop and an allocation on a national machine. between those two things sits weeks of work that has nothing to do with their science: mpi topologies, schedulers, queue etiquette, and the near-certainty that the first genuinely large run is also the first time anyone has found out whether the code scales. that run is expensive, and when it fails it usually fails for a reason that has nothing to do with the physics.
+
+the argument in the piece is that this gap is an engineering problem rather than a fact of nature, and that treating it as a rite of passage is how a field ends up accessible only to people who already know the folklore. domain scientists should be able to spend their allocation on science, not on discovering that their halo exchange deadlocks above four thousand ranks.
+
+[read the full article](https://www.asianscientist.com/2019/03/features/supercomputing-shouldnt-be-rocket-science/)

--- a/src/content/blog/190426_archanan-launch.md
+++ b/src/content/blog/190426_archanan-launch.md
@@ -11,6 +11,6 @@ the problem we were built around: most supercomputing centres allocate ten perce
 
 what we sold was a functional replica. you develop against an emulation of your target machine's topology and interconnect, at the core count you will actually run on, through a web ide with a parallel debugger attached. it is explicitly not a performance model — the layers of virtualisation mean the timings are not the production timings — but it answers the question that actually burns allocation, which is whether the thing runs at all at scale and how mpi behaves when it does. at launch you could target emulated systems including nscc singapore's aspire-1, or specify a machine that did not exist yet.
 
-lukasz orlowski and i founded it in february 2018, raised a seed round led by sginnovate, and had john gustafson — of gustafson's law — as lead scientific advisor, which remains the most straightforwardly cool sentence in my career.
+lukasz orlowski and i founded it in february 2018, raised a seed round led by sginnovate, and had john gustafson, of gustafson's law, as lead scientific advisor.
 
 [read the full article](https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/)

--- a/src/content/blog/190426_archanan-launch.md
+++ b/src/content/blog/190426_archanan-launch.md
@@ -1,10 +1,16 @@
 ---
 title: 'Singapore Startup Hatches At-Scale HPC Dev Cloud'
 date: '2019-04-26'
-description: 'Coverage of our HPC development cloud platform launch in Singapore'
+description: "HPCwire covers Archanan's emergence from stealth — a cloud platform that emulates a target supercomputer so you can develop and debug at full scale."
 category: 'Press'
 ---
 
-HPCwire covered our emergence from stealth with the beta launch of Archanan's cloud-based HPC development platform, designed to give developers on-demand access to virtual replicas of production supercomputing environments. The article details how we're addressing the challenge of limited development cycles at supercomputer centers by enabling large-scale code development and testing in the cloud.
+hpcwire covered our beta launch, which was the first time we said in public what archanan actually did.
 
-[Read the full article](https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/)
+the problem we were built around: most supercomputing centres allocate ten percent or less of the machine to development work. if your production run needs thirty thousand cores, you are writing and debugging that code somewhere much smaller and hoping. plenty of organisations have no on-premise cycles for development at all, and anyone evaluating an architecture they do not own yet has nowhere to try it.
+
+what we sold was a functional replica. you develop against an emulation of your target machine's topology and interconnect, at the core count you will actually run on, through a web ide with a parallel debugger attached. it is explicitly not a performance model — the layers of virtualisation mean the timings are not the production timings — but it answers the question that actually burns allocation, which is whether the thing runs at all at scale and how mpi behaves when it does. at launch you could target emulated systems including nscc singapore's aspire-1, or specify a machine that did not exist yet.
+
+lukasz orlowski and i founded it in february 2018, raised a seed round led by sginnovate, and had john gustafson — of gustafson's law — as lead scientific advisor, which remains the most straightforwardly cool sentence in my career.
+
+[read the full article](https://www.hpcwire.com/2019/04/26/singapore-startup-hatches-hpc-dev-cloud/)

--- a/src/content/blog/191007_hpcwire-feature.md
+++ b/src/content/blog/191007_hpcwire-feature.md
@@ -1,10 +1,14 @@
 ---
 title: 'Try Before You Buy? Test Driving a Supercomputer System'
 date: '2019-10-07'
-description: 'Article about testing supercomputer systems before purchase'
+description: 'A piece for HPCwire on emulating a supercomputer before you buy one — turning procurement from a bet on benchmarks into a question you can answer with your own code.'
 category: 'Press'
 ---
 
-In this article, I explore how organizations can leverage cloud-based emulation to test-drive supercomputer systems before making major purchasing commitments, eliminating the traditional risks of over or under-provisioning expensive HPC infrastructure. Through our work at Archanan, we've developed a platform that creates digital twins of supercomputing systems, enabling real-time development and testing at scale while accelerating the procurement process for both buyers and vendors.
+a follow-up piece for hpcwire, this one about procurement rather than development.
 
-[Read the full article](https://www.hpcwire.com/2019/10/07/try-before-you-buy-test-driving-a-supercomputer-system/)
+buying a supercomputer means committing tens of millions to a configuration chosen largely from benchmarks that are not your workload. get it wrong in one direction and you have paid for capability that sits idle; get it wrong in the other and the machine is saturated the month it arrives. the usual mitigations — vendor benchmarks, reference customers, a proof of concept on last generation's hardware — all stop short of the thing you actually want to know, which is how your codes behave on this machine.
+
+emulating the system first turns that into an empirical question. run the real applications against a digital twin of the proposed configuration and find out whether you are short on interconnect bandwidth or on node count, before the purchase order rather than after. that helps the vendor as much as the buyer: most of the risk in a deal that size is a customer discovering eighteen months later that they bought the wrong shape of machine, and unhappy reference customers are expensive.
+
+[read the full article](https://www.hpcwire.com/2019/10/07/try-before-you-buy-test-driving-a-supercomputer-system/)

--- a/src/content/blog/200817_qcsim-quantum-simulator.md
+++ b/src/content/blog/200817_qcsim-quantum-simulator.md
@@ -1,12 +1,14 @@
 ---
 title: 'QCSim: Quantum Circuit Simulator in Python'
 date: '2020-08-17'
-description: 'A simple quantum circuit simulator for educational and research purposes'
+description: 'A small quantum circuit simulator in Python, written to understand the subject rather than to be fast at it.'
 category: 'Projects'
 ---
 
-QCSim is a Python-based quantum circuit simulator that provides basic quantum gate operations and allows for the creation and manipulation of quantum circuits. Designed for educational purposes, it offers an accessible way to explore quantum computing concepts.
+a quantum circuit simulator in python, written to understand the subject rather than to be fast at it.
 
-The simulator supports fundamental quantum gates and operations, making it an excellent tool for learning quantum algorithms and understanding quantum circuit behavior without requiring specialized hardware.
+it implements the fundamental gates and lets you assemble and run circuits, which is enough to build up the standard algorithms and watch the state vector do what the textbook says it does. simulating a quantum circuit turns out to be linear algebra on a vector of 2^n amplitudes — gates are unitary matrices, measurement is sampling from the squared magnitudes — and writing that out by hand is the fastest way i know to stop finding quantum computing mysterious.
 
-[View on GitHub](https://github.com/alexandernodeland/QCSim)
+the 2^n is also the point at which you understand why simulation stops being a substitute for hardware. thirty qubits is a billion amplitudes.
+
+[view on github](https://github.com/alexnodeland/QCSim)

--- a/src/content/blog/240630_resume-crew.md
+++ b/src/content/blog/240630_resume-crew.md
@@ -1,12 +1,14 @@
 ---
 title: 'Resume Crew: AI-Powered Career Tools'
 date: '2024-06-30'
-description: 'An AI-powered tool for resume tailoring and interview preparation'
+description: 'A CrewAI system that tailors a resume to a specific posting and prepares you for the interview that follows.'
 category: 'Projects'
 ---
 
-Resume Crew is an AI-powered tool that assists job seekers in tailoring their resumes and preparing for interviews using CrewAI. The system uses specialized AI agents to analyze job descriptions, optimize resume content, and provide personalized interview preparation.
+a crewai system that tailors a resume to a specific job posting, then prepares you for the interview that follows.
 
-This project demonstrates the practical application of multi-agent AI systems in career development, helping users navigate the job market more effectively with AI assistance.
+the agents split the work rather than sharing it. one reads the posting and extracts what is genuinely being asked for, as opposed to what the boilerplate says. one rewrites the resume against that reading. one generates the questions you should expect given the gap between the two.
 
-[View on GitHub](https://github.com/alexandernodeland/resume-crew)
+that separation is the whole reason it works better than a single long prompt. critiquing a resume and rewriting it are different jobs, and a model asked to do both at once will soften the critique to justify the rewrite it has already started composing. splitting them forces the criticism to be written down before anything acts on it.
+
+[view on github](https://github.com/alexnodeland/resume-crew)

--- a/src/content/blog/240706_crewlit.md
+++ b/src/content/blog/240706_crewlit.md
@@ -1,12 +1,14 @@
 ---
 title: 'Crewlit: Multi-Agent AI Systems in Your Browser'
 date: '2024-07-06'
-description: 'A web application that brings the power of CrewAI to your browser'
+description: 'CrewAI in a browser — define agents, tasks and crews in a Streamlit UI instead of a Python file.'
 category: 'Projects'
 ---
 
-Crewlit is a Streamlit-based web application that makes multi-agent AI systems accessible to everyone through an intuitive browser interface. Built on top of CrewAI, it provides a user-friendly way to create, manage, and execute AI crews without requiring technical expertise.
+crewai in a browser, so that building a multi-agent system does not have to start with a python file.
 
-The application features a clean UI for creating tasks, agents, and crews, along with a comprehensive execution interface that handles complex multi-agent workflows seamlessly.
+it is a streamlit app for defining agents, tasks and crews, wiring them together, and running them with the output streaming back as it happens. nothing it does is impossible from a script — the point is that it removes the hour of boilerplate between understanding what a multi-agent system is and having one in front of you.
 
-[View on GitHub](https://github.com/alexnodeland/crewlit)
+this is the most-starred thing i have put on github, which i think says more about how large that hour felt in 2024 than about the code. the interesting design constraint was that a crew is a graph of agents with dependencies, and most people's first instinct is to build it as a list. the ui exists mostly to make the graph visible before you run it.
+
+[view on github](https://github.com/alexnodeland/crewlit)

--- a/src/content/blog/240706_crewlit.md
+++ b/src/content/blog/240706_crewlit.md
@@ -9,6 +9,6 @@ crewai in a browser, so that building a multi-agent system does not have to star
 
 it is a streamlit app for defining agents, tasks and crews, wiring them together, and running them with the output streaming back as it happens. nothing it does is impossible from a script — the point is that it removes the hour of boilerplate between understanding what a multi-agent system is and having one in front of you.
 
-this is the most-starred thing i have put on github, which i think says more about how large that hour felt in 2024 than about the code. the interesting design constraint was that a crew is a graph of agents with dependencies, and most people's first instinct is to build it as a list. the ui exists mostly to make the graph visible before you run it.
+the interesting design constraint is that a crew is a graph of agents with dependencies, and most people's first instinct is to build it as a list. the ui exists mostly to make the graph visible before you run it.
 
 [view on github](https://github.com/alexnodeland/crewlit)

--- a/src/content/blog/240709_vanilla-react.md
+++ b/src/content/blog/240709_vanilla-react.md
@@ -1,12 +1,14 @@
 ---
 title: 'Vanilla ReAct: Minimalist Agent Framework'
 date: '2024-07-09'
-description: 'A straightforward ReAct agent framework for reasoning and acting'
+description: 'A ReAct agent in Python with no framework underneath it — the loop, in the open, against the OpenAI API.'
 category: 'Projects'
 ---
 
-Vanilla ReAct is a minimalist Python framework that implements a Reasoning and Acting (ReAct) agent using the OpenAI API. The framework provides a clean, simple interface for building AI agents that can reason about problems and take actions to solve them.
+a react agent in python with no framework underneath it, written when every agent library was adding abstraction faster than i could read it.
 
-Built without complex conversational AI frameworks, Vanilla ReAct focuses on the core ReAct pattern, making it perfect for educational purposes and rapid prototyping of agent-based systems.
+react is a small idea. the model reasons about what to do, takes an action, observes the result, and repeats until it decides it is finished. that is a loop, a prompt template, and a way to dispatch tool calls — it fits on a page against the openai api.
 
-[View on GitHub](https://github.com/alexandernodeland/vanilla-react)
+the repository is that page, kept deliberately readable. it is not trying to compete with the frameworks; it is trying to be the thing you read first, so that when you do adopt one you can tell which parts are solving your problem and which parts are solving the framework's. quite a lot of what gets called an agent is this loop with retries and logging around it.
+
+[view on github](https://github.com/alexnodeland/vanilla-react)

--- a/src/content/blog/240809_finance-crew.md
+++ b/src/content/blog/240809_finance-crew.md
@@ -1,12 +1,14 @@
 ---
 title: 'Finance Crew: AI-Powered Financial Analysis'
 date: '2024-08-09'
-description: 'An AI-powered financial analysis tool using multi-agent systems'
+description: 'A CrewAI system for market analysis — agents that pull data, develop a strategy, and separately assess the risk of running it.'
 category: 'Projects'
 ---
 
-Finance Crew is an AI-powered financial analysis tool that leverages multi-agent systems to provide comprehensive financial insights and analysis. The system uses specialized AI agents to process financial data, generate reports, and provide actionable recommendations.
+a crewai system for market analysis: agents that pull financial data, work a strategy up against it, and assess the risk of actually running that strategy.
 
-This project demonstrates the practical application of multi-agent AI systems in the financial domain, showcasing how different AI agents can collaborate to solve complex analytical tasks.
+the part worth stealing is the separation between the agent that proposes and the agent that assesses. a system that only proposes will always sound confident, because fluent writing about a trade and a good trade are produced by exactly the same machinery. giving the risk assessment its own step, with its own context and no stake in the proposal, is the cheapest available correction for that.
 
-[View on GitHub](https://github.com/alexandernodeland/finance-crew)
+it is a study in multi-agent design, not financial advice, and i would treat any number it produces as a prompt for your own analysis rather than a conclusion.
+
+[view on github](https://github.com/alexnodeland/finance-crew)

--- a/src/content/blog/250819_fugue.md
+++ b/src/content/blog/250819_fugue.md
@@ -1,12 +1,18 @@
 ---
 title: 'Fugue: Monadic Probabilistic Programming for Rust'
 date: '2025-08-19'
-description: 'A type-safe, monadic probabilistic programming library for Rust'
+description: 'A probabilistic programming library for Rust built around a monad — models compose in direct style, and pluggable interpreters decide what running one means.'
 category: 'Projects'
 ---
 
-Fugue is a production-ready, monadic probabilistic programming library for Rust that enables elegant probabilistic programming by composing `Model` values in direct style. The library provides pluggable interpreters and state-of-the-art inference algorithms, making it perfect for Bayesian modeling and statistical computing.
+a probabilistic programming library for rust, built around a monad.
 
-Key features include type-safe distributions with natural return types, multiple inference methods (MCMC, SMC, Variational Inference, ABC), comprehensive diagnostics, and ergonomic macros for do-notation and vectorization.
+a model in fugue is a `Model<T>` value that you compose in direct style with `bind` and `map`. what that composition _means_ is decided later, by the interpreter you hand it to — sample from the prior, replay a trace, score it, or run mcmc, hmc, smc, variational inference or abc over it. separating the model from the inference is the entire point. in most probabilistic languages the algorithm is entangled with how you declare the model, so trying a different sampler means rewriting the thing you were trying to hold constant.
 
-[View on GitHub](https://github.com/alexnodeland/fugue)
+the distributions are typed with their natural return types, which sounds minor and is not. bernoulli gives you a `bool`, poisson and binomial give you `u64`, categorical gives you a `usize` — rather than everything collapsing to `f64` and being cast back at the point of use, which is where the off-by-one lives. seventeen distributions, all with validated parameters, and log-space arithmetic throughout so that multiplying a few thousand small probabilities does not quietly become zero.
+
+there are macros for do-notation (`prob!`) and vectorisation (`plate!`), because monadic code in rust without them is unreadable and pretending otherwise helps nobody.
+
+it is 0.2.x — pre-1.0, no semver guarantees yet, one primary maintainer. extensively tested, including property-based tests and statistical regressions against closed-form posteriors, but that is a different claim from production-ready. pin an exact version and read the changelog before upgrading.
+
+[view on github](https://github.com/alexnodeland/fugue) · [learn it interactively at fugue.run](https://fugue.run)

--- a/src/content/blog/250928_interactive-algorithm-visualizations.md
+++ b/src/content/blog/250928_interactive-algorithm-visualizations.md
@@ -1,108 +1,101 @@
 ---
-title: 'Interactive Algorithm Visualizations as My Website Backgrounds'
+title: 'What Is Running Behind This Page'
 date: '2025-09-28'
-description: 'Explore animated visualizations of fundamental algorithms - from cellular automata to pathfinding - that transform abstract computer science into engaging, interactive experiences'
+description: "Six simulations render the backgrounds on this site — Conway's Life, a simulated-annealing graph search, an FM synthesizer, A*, and a finite-difference PDE solver. What each one computes and what the controls do."
 category: 'Projects'
 ---
 
-throughout my career - from researching audio compression to architecting ai systems - i've always been fascinated by the elegant mathematics underlying complex technologies. but there's often a gap between beautiful theory and intuitive understanding.
+the backgrounds on this site are running, not looping. every one is computed per frame in your browser. the gear icon in the corner opens a panel with the parameters for whichever is on screen, and they cycle every twelve seconds unless you turn that off.
 
-that's why i built **interactive algorithm visualizations** right into this website. click the settings gear in any corner and you'll discover a playground of animated backgrounds - each one a living demonstration of fundamental concepts that power our digital world.
+six of them, in cycle order:
 
-## why visualize algorithms?
-
-abstract concepts become concrete when you can see them in action. watch cellular automaton cells evolve, observe pathfinding algorithms explore networks, or see wave interference create complex patterns in real-time. these aren't just pretty graphics - they're educational tools that make complex ideas accessible.
-
-each visualization connects directly to my experience:
-
-- **cellular automata** → ai and complex systems work
-- **wave interference** → audio engineering and signal processing research
-- **graph theory job scheduling** → distributed systems architecture
-- **fm synthesis** → music technology and creative coding
-- **pathfinding algorithms** → optimization concepts i use daily
-- **pde solver** → numerical methods and physical simulation
-
-## the intersection of art and science
-
-these animations represent something i'm passionate about: where technical rigor meets creative expression. they're computational art that teaches fundamental algorithms, and educational tools that happen to be beautiful.
-
-this reflects my broader philosophy - the best technical solutions have inherent elegance. complex systems can be both deeply sophisticated and intuitively understandable when presented thoughtfully.
-
-## explore the algorithms
-
-- [cellular automata: emergence in action](#cellular-automata)
-- [wave interference: mathematical harmony](#wave-interference)
-- [graph theory job scheduling: distributed computing](#job-scheduling)
-- [fm synthesis: mathematical music](#fm-synthesis)
-- [pathfinding algorithms: routing intelligence](#pathfinding)
-- [pde solver: simulating the physical world](#pde-solver)
+| background         | what it is                                       |
+| ------------------ | ------------------------------------------------ |
+| cellular automaton | conway's life, plus five other b/s rules         |
+| simple waves       | three summed sine waves                          |
+| job scheduling     | simulated annealing over a clustered graph       |
+| dual fm oscillator | a working fm synth, oscilloscope and spectrogram |
+| shortest path      | dijkstra, a\*, and greedy search, side by side   |
+| pde solver         | finite-difference heat and wave equations        |
 
 ---
 
-## <a id="cellular-automata"></a>cellular automata: emergence in action
+## <a id="cellular-automata"></a>cellular automaton
 
-emergence has fascinated me since my early research days - the moment when individual components following simple rules suddenly exhibit behaviors no single component could achieve alone.
+a grid of cells, a rule, and a state buffer stepped one generation at a time. each cell counts its eight neighbours on a wrapping torus, then lives, dies, or is born according to the rule — conway's b3/s23 by default, with highlife, maze, coral, day & night and seeds in the dropdown.
 
-i see this constantly in the ai systems i architect. individual neural network weights, simple mathematical functions, yet together they generate language, recognize patterns, make decisions. in distributed computing, simple containers and services create resilient, self-healing systems.
+the shader only draws; the rule runs on a real buffer. newborn cells take the newborn colour and shift toward the established colour the longer they survive, and links are drawn between live neighbours — the same eight-cell neighbourhood the rule is evaluated over.
 
-this visualization captures that same magic - the moment when local interactions become global intelligence.
-
----
-
-## <a id="wave-interference"></a>wave interference: mathematical harmony
-
-my fascination with wave interference started during my audio compression research - discovering how the same mathematics that creates musical harmony also powers noise cancellation, wireless communications, and quantum mechanics.
-
-i spent years working on optimal wavelet bases for audio compression, watching how simple mathematical transformations could capture the essence of complex sounds. there's something profound about how waves - whether sound, light, or radio - follow the same fundamental principles.
-
-this visualization represents the mathematical foundation underlying so much of the signal processing work that shaped my technical perspective.
+random soup under conway settles into still lifes and period-two oscillators within a couple of hundred generations, which for a background is death. `perturbation rate` flips a small fraction of cells each step to keep things moving. set it to zero and it will stall on its own, which is the honest behaviour and worth seeing once.
 
 ---
 
-## <a id="job-scheduling"></a>graph theory job scheduling: distributed computing
+## <a id="wave-interference"></a>simple waves
 
-architecting distributed systems means constantly solving resource allocation puzzles - which workloads run where, how to balance load, how to handle failures gracefully.
+three sine waves summed in a shader. one runs along x, one along y at 0.8× the frequency, one diagonally at 0.6×, each drifting at a different rate. colour maps amplitude: bright where they reinforce, dark where they cancel.
 
-i've spent countless hours designing kubernetes deployments, optimizing aws infrastructure, and building resilient cloud architectures. every decision involves finding the optimal match between job requirements and available resources across complex, dynamic networks.
+this is superposition and nothing more, which is the point — interference is the whole mechanism behind a great deal of signal processing, and it is three lines of arithmetic. i spent a couple of years on wavelet bases for audio compression at stony brook and the thing that stays with me is how little machinery the underlying physics actually needs.
 
-what draws me to this problem is the elegant mathematical structure underlying messy real-world infrastructure. graph theory provides a clean lens for understanding the chaos of distributed computing.
-
----
-
-## <a id="fm-synthesis"></a>fm synthesis: mathematical music
-
-music technology represents everything i love about engineering - rigorous mathematics in service of human creativity and expression.
-
-during my time as artist in residence at cewit, i designed and built audio synthesizers, exploring how mathematical functions could generate emotionally resonant sounds. fm synthesis became a particular obsession - the way simple frequency relationships could create infinite timbral complexity.
-
-this visualization embodies my philosophy that the best technical work serves human creativity. mathematics and engineering aren't just tools - they're instruments for artistic expression.
+turn `wave frequency` up and `wave speed` down to freeze the interference pattern in place.
 
 ---
 
-## <a id="pathfinding"></a>pathfinding algorithms: routing intelligence
+## <a id="job-scheduling"></a>job scheduling
 
-optimization problems define so much of what i do - finding the best path through complex solution spaces, whether architecting systems, designing algorithms, or making strategic technical decisions.
+the most interesting one, and the worst named.
 
-these algorithms represent different philosophies i encounter constantly: the perfectionist approach that guarantees optimal solutions but demands computational resources, the intelligent balance that uses smart heuristics to achieve optimality efficiently, and the pragmatic speedster that sacrifices some optimality for real-time performance.
+it builds a clustered graph: nodes grouped into tight clusters with dense, high-bandwidth links inside each cluster and sparse, high-latency links between them. roughly the shape of a real datacenter. then it searches for the subgraph of size _n_ with the highest total conductivity — the best-connected group of that size.
 
-i chose to visualize pathfinding because it makes visible the invisible trade-offs that shape every technical decision - thoroughness versus speed, optimality versus practicality, perfection versus "good enough." it's the fundamental tension in all engineering work.
+that search is simulated annealing with an exponential cooling schedule. it proposes a swap, accepts it outright if it scores better, and accepts it with a temperature-dependent probability if it scores worse. early on, while it is hot, it takes bad trades freely and wanders. as the temperature drops it stops accepting losses and settles. the two highlight colours are separate things: one is the candidate set it is considering right now, the other is the best set it has found so far. early on they diverge constantly. near the end they lock together.
 
----
+the layout is force-directed and running at the same time, so the graph is still settling while the search runs over it.
 
-## <a id="pde-solver"></a>pde solver: simulating the physical world
-
-partial differential equations sit at the heart of how we model the physical world - heat flowing through materials, waves propagating across surfaces, quantum particles evolving in time. they're the mathematical language nature uses to describe change across space and time simultaneously.
-
-i've always been drawn to numerical methods because they turn continuous mathematics into something a computer can actually compute. finite difference schemes, stability conditions, cfl constraints - these aren't just academic exercises. they're the same techniques used in weather forecasting, structural engineering, and fluid dynamics simulations.
-
-this visualization solves the heat equation and wave equation in real time using explicit finite difference methods. watching thermal diffusion smooth out an initial temperature distribution, or seeing waves reflect off boundaries and interfere with themselves, makes the underlying mathematics tangible in a way that equations on paper never quite achieve.
+set `number of clusters` to 2 and `requested subgraph size` to something close to one cluster's worth of nodes, then watch how long it takes to commit to one side.
 
 ---
 
-## dive in and explore
+## <a id="fm-synthesis"></a>dual fm oscillator
 
-these visualizations represent my attempt to bridge the gap between abstract mathematical concepts and intuitive understanding. every background connects to work i've done, problems i've solved, or domains that have shaped my thinking.
+a functioning synthesizer. two oscillators, where one modulates the other's phase — that is the whole trick behind fm synthesis, and it is why a dx7 could make a bell out of two sine waves when subtractive synths needed a filter bank. the signal then runs through filter, delay, distortion and reverb.
 
-they're computational art with a purpose - making the invisible mathematics that powers our digital world a little more visible, a little more playful, and a lot more engaging.
+top display is an oscilloscope: amplitude against time. bottom is a spectrogram: frequency low-to-high, scrolling left-to-right, brightness as intensity. every bin is a hann-windowed discrete fourier transform of the same samples the oscilloscope is drawing, so the sidebands, the harmonic series of a square wave, and the sum and difference tones from the ring modulator are all measured rather than drawn. watching one signal in both domains at once is the fastest way i know to build intuition for what fm does to a spectrum.
 
-_click the gear icon to start exploring. each visualization is a window into the mathematical foundations of the systems we use every day._
+push `vco 1 fm amount` up slowly and watch the sidebands appear in pairs either side of the carrier, spaced at the modulator frequency.
+
+it makes sound. hold the speaker button in the settings panel.
+
+i built synthesizers as artist in residence at cewit for a year, mostly analogue, and this is the part of the site that most resembles what i actually enjoy doing.
+
+---
+
+## <a id="pathfinding"></a>shortest path
+
+seeded random graph, real priority frontier, and one slider that changes which algorithm you are running.
+
+`heuristic weight` scales the heuristic term in `f = g + w·h`:
+
+- **w = 0** — the heuristic vanishes and it is dijkstra. explores outward in every direction equally. always finds the optimal path, looks at far more of the graph than it needed to.
+- **w = 1** — a\*. the heuristic is admissible, so the path is still optimal, but exploration stretches toward the goal instead of spreading evenly.
+- **w > 1** — greedy. it over-trusts the heuristic, drives almost straight at the goal, and gives up the optimality guarantee to do it.
+
+the shape of the explored region is the thing to watch: a circle, then an ellipse, then a corridor. that is the entire optimality-versus-effort tradeoff rendered as a shape, and it is why i left this one in the rotation.
+
+turn `steps per second` down to about 5 to watch the frontier expand node by node.
+
+---
+
+## <a id="pde-solver"></a>pde solver
+
+explicit finite differences on a grid, solving either the heat equation `∂u/∂t = α∇²u` or the wave equation `∂²u/∂t² = c²∇²u`. the laplacian is a five-point stencil; heat uses forward-time centred-space, wave uses a centred second difference in time. grid runs at 64², 128² or 256².
+
+the parameters that change the physics rather than the look are `boundary condition` and `initial condition`. dirichlet fixes the edge value, so waves reflect inverted. neumann sets the edge derivative to zero, so they reflect upright. periodic wraps, so anything leaving the right edge arrives at the left. pick a gaussian pulse on the wave equation and switch between the three — the difference in reflection is immediate and it is the clearest demonstration of boundary conditions i have found.
+
+you cannot make it explode. explicit schemes are only conditionally stable — heat needs `α·dt·(1/dx² + 1/dy²) ≤ 0.5`, wave needs the cfl condition `c·dt·√(1/dx² + 1/dy²) ≤ 1` — so the timestep is clamped to the stable maximum before every step. push thermal diffusivity to its limit and the simulation slows down rather than diverging.
+
+---
+
+## on the whole thing
+
+they render to webgl or canvas depending on the background, pause when the tab is hidden, and cycle on a twelve-second timer with a 1.2-second crossfade. every parameter you change is live.
+
+the actual reason they exist: a static background is a wasted surface, and i wanted somewhere to put the numerical methods i do not otherwise get to write at work.

--- a/src/content/blog/250928_interactive-algorithm-visualizations.md
+++ b/src/content/blog/250928_interactive-algorithm-visualizations.md
@@ -64,7 +64,7 @@ push `vco 1 fm amount` up slowly and watch the sidebands appear in pairs either 
 
 it makes sound. hold the speaker button in the settings panel.
 
-i built synthesizers as artist in residence at cewit for a year, mostly analogue, and this is the part of the site that most resembles what i actually enjoy doing.
+i built synthesizers as artist in residence at cewit for a year, mostly analogue.
 
 ---
 

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -66,8 +66,8 @@ const BlogPage: React.FC<BlogPageProps> = ({ data }) => {
         <header className="blog-header">
           <h1>blog</h1>
           <p>
-            thoughts on technology, projects, and the occasional deep dive into
-            interesting problems.
+            what i&apos;ve built and what i&apos;ve been quoted saying, going
+            back to 2015.
           </p>
         </header>
 

--- a/src/pages/cv.tsx
+++ b/src/pages/cv.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   CVSectionNav,
   EducationSection,
@@ -8,10 +8,15 @@ import {
   SEO,
   SkillsSection,
 } from '../components';
-import { cvData } from '../config';
+import { cvData, resumeData } from '../config';
 import '../styles/cv.scss';
 
+type CVView = 'full' | 'resume';
+
 const CVPage: React.FC = () => {
+  const [view, setView] = useState<CVView>('full');
+  const data = view === 'resume' ? resumeData : cvData;
+
   return (
     <Layout>
       <SEO title="cv" description="Complete resume and CV for Alex Nodeland" />
@@ -19,13 +24,38 @@ const CVPage: React.FC = () => {
         <header className="cv-page-header">
           <h1>cv</h1>
           <p>
-            comprehensive overview of my professional experience, skills, and
-            achievements
+            {view === 'full'
+              ? 'everything, in order, back to 2010.'
+              : 'the short version — recent roles only, trimmed to one page.'}{' '}
+            export it as pdf, docx, or markdown below.
           </p>
         </header>
 
+        <div
+          className="cv-view-toggle"
+          role="group"
+          aria-label="Choose CV length"
+        >
+          <button
+            type="button"
+            className={`cv-view-button ${view === 'full' ? 'active' : ''}`}
+            onClick={() => setView('full')}
+            aria-pressed={view === 'full'}
+          >
+            full cv
+          </button>
+          <button
+            type="button"
+            className={`cv-view-button ${view === 'resume' ? 'active' : ''}`}
+            onClick={() => setView('resume')}
+            aria-pressed={view === 'resume'}
+          >
+            one page
+          </button>
+        </div>
+
         <ExportButtons
-          resumeData={cvData}
+          resumeData={data}
           resumeElementId="resume-content"
           className="cv-export"
         />
@@ -36,7 +66,7 @@ const CVPage: React.FC = () => {
             { id: 'cv-experience', label: 'Experience', mobileLabel: 'Exp' },
             { id: 'cv-education', label: 'Education', mobileLabel: 'Edu' },
             { id: 'cv-skills', label: 'Skills', mobileLabel: 'Skills' },
-            ...(cvData.certifications && cvData.certifications.length > 0
+            ...(data.certifications && data.certifications.length > 0
               ? [
                   {
                     id: 'cv-certifications',
@@ -51,45 +81,43 @@ const CVPage: React.FC = () => {
         <div className="cv-overview-contact">
           <div className="overview-section">
             <h3>overview</h3>
-            <p>{cvData.personal.summary}</p>
+            <p>{data.personal.summary}</p>
           </div>
           <div className="contact-section">
             <h3>contact</h3>
             <div className="contact-grid">
               <div className="contact-item">
                 <span className="contact-label">location</span>
-                <span className="contact-value">
-                  {cvData.personal.location}
-                </span>
+                <span className="contact-value">{data.personal.location}</span>
               </div>
               <div className="contact-item">
                 <span className="contact-label">email</span>
                 <a
-                  href={`mailto:${cvData.personal.email}`}
+                  href={`mailto:${data.personal.email}`}
                   className="contact-value"
                 >
-                  {cvData.personal.email}
+                  {data.personal.email}
                 </a>
               </div>
               <div className="contact-item">
                 <span className="contact-label">website</span>
                 <a
-                  href={`https://${cvData.personal.website}`}
+                  href={`https://${data.personal.website}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="contact-value"
                 >
-                  {cvData.personal.website}
+                  {data.personal.website}
                 </a>
               </div>
-              {cvData.personal.phone && (
+              {data.personal.phone && (
                 <div className="contact-item">
                   <span className="contact-label">phone</span>
                   <a
-                    href={`tel:${cvData.personal.phone}`}
+                    href={`tel:${data.personal.phone}`}
                     className="contact-value"
                   >
-                    {cvData.personal.phone}
+                    {data.personal.phone}
                   </a>
                 </div>
               )}
@@ -99,22 +127,22 @@ const CVPage: React.FC = () => {
 
         <div id="resume-content">
           <section id="cv-experience">
-            <ExperienceSection experiences={cvData.experience} />
+            <ExperienceSection experiences={data.experience} />
           </section>
 
           <section id="cv-education">
-            <EducationSection education={cvData.education} />
+            <EducationSection education={data.education} />
           </section>
 
           <section id="cv-skills">
-            <SkillsSection skills={cvData.skills} />
+            <SkillsSection skills={data.skills} />
           </section>
 
-          {cvData.certifications && cvData.certifications.length > 0 && (
+          {data.certifications && data.certifications.length > 0 && (
             <section id="cv-certifications">
               <h2 className="cv-section-title">Certifications</h2>
               <div className="certifications-container">
-                {cvData.certifications.map((cert, index) => {
+                {data.certifications.map((cert, index) => {
                   // Create a shorter name for the chip - be more careful with word boundaries
                   let shortName = cert.name
                     // Remove common certification words only when they're complete words

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const IndexPage: React.FC = () => {
     <Layout>
       <SEO
         title="home"
-        description="Experienced engineer and mathematician with a background in distributed computing and creative technology"
+        description="AI engineer and mathematician. Agent systems, distributed infrastructure, and audio DSP."
       />
       <div className="home">
         <section className="hero">
@@ -108,12 +108,11 @@ const IndexPage: React.FC = () => {
         </section>
 
         <section className="blog-preview">
-          <h2>insights & experiments</h2>
+          <h2>writing</h2>
           <p>
-            exploring the cutting edge of ai engineering, devops automation, and
-            system architecture. dive into my{' '}
-            <a href="/blog">latest insights</a> on building production ai
-            systems.
+            notes on things i&apos;ve built, plus press and research going back
+            to 2015 — supercomputing, audio compression, and whatever i&apos;m
+            currently taking apart. <a href="/blog">read the blog</a>.
           </p>
         </section>
       </div>

--- a/src/styles/animated-backgrounds.scss
+++ b/src/styles/animated-backgrounds.scss
@@ -464,6 +464,71 @@
       hyphens: auto;
     }
 
+    // Help affordance next to a control's label. Keyboard reachable, and the
+    // description is also on aria-label so screen readers get it without
+    // needing hover.
+    .setting-help {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 0.95rem;
+      height: 0.95rem;
+      margin-left: 0.35rem;
+      border-radius: 50%;
+      border: 1px solid var(--border-color);
+      color: var(--text-secondary);
+      font-size: 0.6rem;
+      line-height: 1;
+      cursor: help;
+      vertical-align: middle;
+      transition: all var(--transition-fast);
+
+      &:hover,
+      &:focus-visible {
+        color: var(--text-primary);
+        border-color: var(--primary-color);
+        outline: none;
+      }
+
+      .setting-tooltip {
+        position: absolute;
+        bottom: calc(100% + 0.4rem);
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 10;
+        width: max-content;
+        max-width: 15rem;
+        padding: 0.5rem 0.65rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-color);
+        background: var(--bg-card);
+        color: var(--text-primary);
+        font-size: 0.7rem;
+        line-height: 1.45;
+        text-transform: none;
+        text-align: left;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity var(--transition-fast);
+        pointer-events: none;
+      }
+
+      // Flipped below the icon when there is not enough room above inside the
+      // scrolling list; the class is set on hover/focus by positionTooltip.
+      &.flip .setting-tooltip {
+        bottom: auto;
+        top: calc(100% + 0.4rem);
+      }
+
+      &:hover .setting-tooltip,
+      &:focus-visible .setting-tooltip {
+        opacity: 1;
+        visibility: visible;
+      }
+    }
+
     .setting-input {
       display: flex;
       align-items: center;

--- a/src/styles/blog.scss
+++ b/src/styles/blog.scss
@@ -689,7 +689,14 @@
 
     p {
       color: rgba(255, 255, 255, 0.95);
-      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      // Two layers rather than one: a tight near-opaque halo holds an edge
+      // against an adjacent bright cell, and a wider soft one fills the gaps.
+      // A single 4px blur was tuned for the low-frequency backgrounds and does
+      // not survive the cellular automaton, which alternates light and dark
+      // every cell.
+      text-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.9),
+        0 0 10px rgba(0, 0, 0, 0.6);
     }
   }
 

--- a/src/styles/blog.scss
+++ b/src/styles/blog.scss
@@ -563,6 +563,47 @@
     background: var(--border-color);
     margin: 3rem 0;
   }
+
+  // Tables scroll independently so wide content never scrolls the page body
+  .table-wrapper,
+  table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: 2rem 0;
+    font-size: 0.95rem;
+
+    th,
+    td {
+      padding: 0.6rem 1rem;
+      text-align: left;
+      border-bottom: 1px solid var(--border-color);
+      vertical-align: top;
+    }
+
+    th {
+      font-family:
+        'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+        monospace;
+      text-transform: lowercase;
+      letter-spacing: -0.02em;
+      color: var(--text-primary);
+      border-bottom-width: 2px;
+      white-space: nowrap;
+    }
+
+    td {
+      color: var(--text-secondary);
+    }
+
+    tbody tr:last-child td {
+      border-bottom: none;
+    }
+  }
 }
 
 .post-footer {

--- a/src/styles/cv.scss
+++ b/src/styles/cv.scss
@@ -1675,3 +1675,38 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     }
   }
 }
+
+// Full CV / one-page resume switch, sits above the export buttons
+.cv-view-toggle {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+
+  .cv-view-button {
+    padding: 0.5rem 1.25rem;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-family:
+      'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
+      monospace;
+    font-size: 0.9rem;
+    text-transform: lowercase;
+    letter-spacing: -0.01em;
+    cursor: pointer;
+    transition: all var(--transition-normal);
+
+    &:hover {
+      color: var(--text-primary);
+      border-color: var(--primary-color);
+    }
+
+    &.active {
+      color: var(--text-primary);
+      border-color: var(--primary-color);
+      box-shadow: 0 0 12px rgba(0, 255, 136, 0.25);
+    }
+  }
+}

--- a/src/styles/cv.scss
+++ b/src/styles/cv.scss
@@ -1465,7 +1465,14 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
     p {
       color: rgba(255, 255, 255, 0.95);
-      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      // Two layers rather than one: a tight near-opaque halo holds an edge
+      // against an adjacent bright cell, and a wider soft one fills the gaps.
+      // A single 4px blur was tuned for the low-frequency backgrounds and does
+      // not survive the cellular automaton, which alternates light and dark
+      // every cell.
+      text-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.9),
+        0 0 10px rgba(0, 0, 0, 0.6);
     }
   }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -412,7 +412,14 @@
 
     .hero-subtitle {
       color: rgba(255, 255, 255, 0.95);
-      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      // Two layers rather than one: a tight near-opaque halo holds an edge
+      // against an adjacent bright cell, and a wider soft one fills the gaps.
+      // A single 4px blur was tuned for the low-frequency backgrounds and does
+      // not survive the cellular automaton, which alternates light and dark
+      // every cell.
+      text-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.9),
+        0 0 10px rgba(0, 0, 0, 0.6);
     }
   }
 

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -475,7 +475,14 @@
 
     p {
       color: rgba(255, 255, 255, 0.95);
-      text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
+      // Two layers rather than one: a tight near-opaque halo holds an edge
+      // against an adjacent bright cell, and a wider soft one fills the gaps.
+      // A single 4px blur was tuned for the low-frequency backgrounds and does
+      // not survive the cellular automaton, which alternates light and dark
+      // every cell.
+      text-shadow:
+        0 1px 2px rgba(0, 0, 0, 0.9),
+        0 0 10px rgba(0, 0, 0, 0.6);
     }
   }
 

--- a/src/types/animated-backgrounds.ts
+++ b/src/types/animated-backgrounds.ts
@@ -134,6 +134,13 @@ export interface SettingsSchema {
   step?: number;
   options?: { value: any; label: string }[];
   category?: string;
+  /**
+   * What the control does and what to watch when you move it. Shown as a
+   * tooltip beside the label. Keep in step with the same field on
+   * `core/types.ts` — the configs are authored against that one and this is
+   * what the settings panel renders from.
+   */
+  description?: string;
 }
 
 export interface BackgroundManagerState {


### PR DESCRIPTION
The site read as AI-generated, so this rewrites the copy in a plainer voice. Describing the backgrounds precisely turned out to be the useful part: two of them were not computing what they claimed, and neither survived being written down.

## Two fake backgrounds

**The cellular automaton was not one.** Cell state was a closed-form function of position and time; nothing was iterated and there was no previous generation to read. It is now a real Life-like automaton — a `Uint8Array` state buffer stepped by an eight-neighbour count on a wrapping torus, six B/S rules. The rule lives in `automaton.ts`, free of Three.js, and is tested against known patterns: blinker period-2, block still, glider translating one cell diagonally per four generations, structures crossing the edge intact.

**The FM oscillator had two bugs.** The modulator was added to the carrier's *frequency* and multiplied by `t`, so modulation depth grew without bound instead of producing fixed sidebands; it now modulates phase, per Chowning. And the spectrogram drew an idealised harmonic series on top of a weak correlation rather than measuring anything — replaced with a Hann-windowed quadrature DFT at the same sample budget, so it is both cheaper and correct.

The other four checked out: real simulated annealing, real Dijkstra/A\*, real FTCS with CFL clamping, honest superposition.

## Every background control audited

Cross-referencing each schema key against what its component reads, *and* each declared uniform against what the shader body uses, found **seven controls that did nothing**.

Wired up: **FFT Window Size** (transform was hardcoded to 64 samples), **Spectrogram Smoothing** (now blends the analysis window rectangular→Hann, which is what spectral smoothing means), **Grid Color** in the spectrogram (five hardcoded gridlines), **Background Color** in simple-waves (the wave filled every pixel, so cancellation still painted a wave colour).

Removed: `Grid Color` from three backgrounds that draw no grid, plus a 512×256 RGBA float texture and a 1024-sample waveform texture allocated on every mount and never sampled.

## Tooltips on all 118 controls

There was no tooltip mechanism — only labels. `SettingsSchema` gains `description`, and every control has one saying what changes on screen rather than restating its name. Keyboard reachable, text repeated on `aria-label` so it isn't hover-only, and it flips below its icon when the scrolling list has no room above (88px of clipping before that fix).

## Copy

Rewritten toward the voice already on the projects page. Homepage, site meta, page headers, chat greeting, background descriptions, all 13 blog posts. Every project post had closed with the same dead paragraph — "This project demonstrates the practical application of…" — restating the one above it.

**Four dead links fixed.** `resume-crew`, `QCSim`, `vanilla-react` and `finance-crew` pointed at `github.com/alexandernodeland/…`, which 404s. All 13 links now return 200. The fugue post also called the library "production-ready" while its own README says that is *not* the claim.

**Inferred claims corrected** (`77736ef`). Several statements were my inference in Alex's voice — the Influize database work, the consulting client profile, a lesson attributed to the Motiff era, an aside about Gustafson. Checked and fixed or removed.

## One-page résumé

All ~90 CV bullets rewritten out of the `<verb> X by <gerund>` template and ordered strongest-first, which makes the split cheap: `cvData` stays the single source of truth, roles opt in with `resume: { maxBullets }`, and `getResumeData()` derives the short version — 11 roles/67 bullets → 6/15. `/cv` gains a full/one-page toggle.

## Press archive

`just archive-press` takes local copies of the six linked articles, extracts their text, and resubmits each to the Wayback Machine. The oldest link is a student newspaper. Copies are gitignored — third-party copyrighted work — and nothing in `archive/` reaches the built site. Only the README is tracked, since it pairs each original URL with its Wayback snapshot.

## Deploy cache fix

`deploy.yml` restored `public` alongside `.cache`, which lets Gatsby keep a stale `index.html` referencing an old `styles.<hash>.css` while writing the new one beside it, unreferenced — a CSS-only change deploys with no effect and a green build. This is not hypothetical; it happened locally while verifying the subtitle halo. The old cache key also hashed `public`, the output rather than an input.

## Verification

- `gatsby build` exits 0; 528 tests pass; `tsc` clean; lint shows only 3 pre-existing warnings
- All six shaders verified compiling in a real browser. **Two bugs were caught only this way** — `sample` is a reserved word in GLSL, and I used `uColorGrid` without declaring it. Both built successfully and passed every test.
- All 13 external links checked for 200

## Worth knowing before merging

- **Controls are verified wired, not individually dragged.** Static reference plus shader-body checks plus compile verification is a strong guarantee, but a control could be correctly wired and still too subtle to notice.
- **The automaton reads busier than the old smooth field.** `cell fill`, `opacity` and `generations per second` are exposed if you want to calm it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)