### PR TITLE
Make the site chrome hold up in light mode and on touch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:integration": "jest --testPathPattern=__tests__/integration",
     "test:e2e": "playwright test",
     "eval:chat": "node scripts/chat-eval.mjs",
+    "audit:contrast": "node scripts/audit-contrast.mjs",
     "test:e2e:ui": "playwright test --ui",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:e2e",
     "test:coverage:full": "node scripts/test-coverage.js",

--- a/scripts/audit-contrast.mjs
+++ b/scripts/audit-contrast.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+//
+// Sweeps every page in both themes and reports text that will not read where it
+// sits. Two different failures, because this site has two kinds of surface:
+//
+//   1. Text on a page surface (a card, a panel) that falls under WCAG AA — 4.5:1
+//      against whatever is actually painted behind it, not against the token it
+//      nominally sits on.
+//
+//   2. Text on the animated background with no halo. The backgrounds are the
+//      same six in both themes and run from a near-black graph to a saturated
+//      yellow PDE field, so no single colour survives them. The only defence is
+//      a text-shadow, and this flags anything missing one.
+//
+// Run against the dev server:
+//
+//   npm run develop          # in one shell
+//   npm run audit:contrast   # in another
+//
+// Exits non-zero if anything is flagged, so it can gate a branch if you ever
+// want it to.
+//
+// Known blind spot, reported as `skipped`: an element filled with a CSS
+// gradient has a transparent `backgroundColor`, so there is no single value to
+// measure against and no way to know which stop sits under the text. Those are
+// counted and listed rather than guessed at — check them by eye, or against the
+// darkest stop of the gradient.
+
+import { chromium } from 'playwright';
+
+const BASE_URL = process.env.AUDIT_BASE_URL ?? 'http://localhost:8000';
+const THEMES = ['light', 'dark'];
+const VIEWPORT = { width: 1280, height: 900 };
+
+// AA for body text. Large text is allowed 3:1, but nothing here relies on that,
+// and holding one bar keeps the output honest.
+const MIN_RATIO = 4.5;
+
+/**
+ * Runs in the page. Returns every text-bearing element that fails, plus the
+ * ones it could not judge.
+ */
+const AUDIT = minRatio => {
+  const lin = c => {
+    c /= 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const parse = s => {
+    const m = s.match(
+      /rgba?\(([\d.]+),\s*([\d.]+),\s*([\d.]+)(?:,\s*([\d.]+))?\)/
+    );
+    return m ? [+m[1], +m[2], +m[3], m[4] === undefined ? 1 : +m[4]] : null;
+  };
+  const lum = a => 0.2126 * lin(a[0]) + 0.7152 * lin(a[1]) + 0.0722 * lin(a[2]);
+  const ratio = (a, b) => {
+    const l1 = lum(a);
+    const l2 = lum(b);
+    return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+  };
+  const composite = (fg, bg) =>
+    [0, 1, 2].map(i => fg[i] * fg[3] + bg[i] * (1 - fg[3]));
+
+  const describe = el =>
+    el.tagName.toLowerCase() +
+    (typeof el.className === 'string' && el.className.trim()
+      ? '.' + el.className.trim().split(/\s+/).join('.')
+      : '');
+
+  // Walks up for the first ancestor that actually paints something solid.
+  //
+  // Stops at body on purpose: body's own colour is not what you see, because
+  // the background stage and the simulation canvas are painted over it. Text
+  // whose nearest opaque ancestor is body is text on the animated background.
+  //
+  // A translucent surface below this threshold is treated as not-a-surface,
+  // since what shows through it is the background and therefore unknowable.
+  const OPAQUE_ENOUGH = 0.85;
+  const backdrop = el => {
+    let node = el;
+    while (node && node !== document.body) {
+      const style = getComputedStyle(node);
+      if (style.backgroundImage.includes('gradient')) {
+        return { kind: 'gradient', gradient: style.backgroundImage };
+      }
+      const colour = parse(style.backgroundColor);
+      if (colour && colour[3] > OPAQUE_ENOUGH) {
+        return { kind: 'solid', colour };
+      }
+      node = node.parentElement;
+    }
+    return { kind: 'background' };
+  };
+
+  const failures = [];
+  const skipped = [];
+
+  document.querySelectorAll('body *').forEach(el => {
+    // Only elements holding their own visible text — otherwise every wrapper
+    // reports its children's problems a second time.
+    const own = Array.from(el.childNodes)
+      .filter(node => node.nodeType === Node.TEXT_NODE)
+      .map(node => node.textContent.trim())
+      .join(' ')
+      .trim();
+    if (!own) return;
+
+    const rect = el.getBoundingClientRect();
+    if (rect.width < 4 || rect.height < 4) return;
+
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.opacity === '0') return;
+
+    const fg = parse(style.color);
+    if (!fg) return;
+
+    const hasHalo = style.textShadow && style.textShadow !== 'none';
+    const under = backdrop(el);
+
+    if (under.kind === 'background') {
+      // Painted straight onto the animated background, which can be any
+      // colour. A halo is the whole defence; without one there is nothing.
+      if (hasHalo) return;
+      failures.push({
+        sel: describe(el),
+        text: own.slice(0, 32),
+        ratio: null,
+        colour: style.color,
+        against: 'the animated background, with no halo',
+        size: style.fontSize,
+      });
+      return;
+    }
+
+    if (under.kind === 'gradient') {
+      skipped.push({
+        sel: describe(el),
+        text: own.slice(0, 32),
+        colour: style.color,
+        against: under.gradient.slice(0, 60),
+      });
+      return;
+    }
+
+    // A halo makes the measurement meaningless — the text is no longer sitting
+    // directly on the surface below it.
+    if (hasHalo) return;
+
+    const r = ratio(composite(fg, under.colour), under.colour);
+    if (r >= minRatio) return;
+    failures.push({
+      sel: describe(el),
+      text: own.slice(0, 32),
+      ratio: +r.toFixed(2),
+      colour: style.color,
+      against:
+        'rgb(' + under.colour.slice(0, 3).map(Math.round).join(', ') + ')',
+      size: style.fontSize,
+    });
+  });
+
+  // One row per selector/colour pair — a list of twenty identical chips is one
+  // problem, not twenty.
+  const dedupe = rows => {
+    const seen = new Map();
+    rows.forEach(row => {
+      const key = row.sel + '|' + row.colour + '|' + row.against;
+      if (!seen.has(key)) seen.set(key, row);
+    });
+    return Array.from(seen.values());
+  };
+
+  return {
+    failures: dedupe(failures).sort((a, b) => (a.ratio ?? 0) - (b.ratio ?? 0)),
+    skipped: dedupe(skipped),
+  };
+};
+
+/** The blog post slugs move, so take one from the index rather than pinning it. */
+async function discoverPages(page) {
+  await page.goto(`${BASE_URL}/blog/`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(800);
+  const post = await page.evaluate(() => {
+    const link = Array.from(
+      document.querySelectorAll('a[href^="/blog/"]')
+    ).find(a => a.getAttribute('href') !== '/blog/');
+    return link ? link.getAttribute('href') : null;
+  });
+  return ['/', '/blog/', '/projects/', '/cv/', '/404/', post].filter(Boolean);
+}
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: VIEWPORT });
+
+const pages = await discoverPages(page);
+let totalFailures = 0;
+let totalSkipped = 0;
+
+for (const theme of THEMES) {
+  for (const path of pages) {
+    await page.goto(BASE_URL + path, { waitUntil: 'domcontentloaded' });
+    await page.evaluate(t => localStorage.setItem('theme', t), theme);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    // The backgrounds mount client-side and the cards settle after them.
+    await page.waitForTimeout(900);
+    // Open every collapsible, so what they hide is audited too.
+    await page.evaluate(() =>
+      document.querySelectorAll('details').forEach(d => (d.open = true))
+    );
+    await page.waitForTimeout(200);
+
+    const { failures, skipped } = await page.evaluate(AUDIT, MIN_RATIO);
+    totalFailures += failures.length;
+    totalSkipped += skipped.length;
+
+    const tally = failures.length === 0 ? 'ok' : `${failures.length} failing`;
+    const note = skipped.length ? `, ${skipped.length} on gradients` : '';
+    console.log(`\n${theme.padEnd(5)} ${path.padEnd(28)} ${tally}${note}`);
+
+    failures.forEach(f => {
+      const score = f.ratio === null ? '  —  ' : String(f.ratio).padStart(5);
+      console.log(
+        `  ${score}  ${f.sel}\n         "${f.text}"  ${f.colour} on ${f.against} @${f.size}`
+      );
+    });
+    skipped.forEach(s => {
+      console.log(
+        `     ?   ${s.sel}  "${s.text}"  ${s.colour} on ${s.against}`
+      );
+    });
+  }
+}
+
+await browser.close();
+
+console.log(
+  `\n${totalFailures} failing, ${totalSkipped} on gradients (judge those by eye).`
+);
+process.exit(totalFailures === 0 ? 0 : 1);

--- a/src/components/animated-backgrounds/BackgroundManager.tsx
+++ b/src/components/animated-backgrounds/BackgroundManager.tsx
@@ -246,6 +246,9 @@ const BackgroundManager: React.FC<BackgroundManagerProps> = ({ className }) => {
 
   return (
     <>
+      {/* Constant backing the simulations composite onto, so the set reads the
+          same in both themes rather than picking up the page colour. */}
+      <div className="background-stage" aria-hidden="true" />
       {renderCurrentBackground()}
       <div
         style={{

--- a/src/components/cv/CVEducationSection.tsx
+++ b/src/components/cv/CVEducationSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useScrollSpy } from '../../lib/hooks';
 import { EducationItem } from '../../types';
 
 interface CVEducationSectionProps {
@@ -10,11 +11,21 @@ const CVEducationSection: React.FC<CVEducationSectionProps> = ({
   education,
   className,
 }) => {
+  const { containerRef, isActive } = useScrollSpy<HTMLElement>(
+    'details.cv-collapse'
+  );
+
   return (
-    <section className={`education-section${className ? ` ${className}` : ''}`}>
+    <section
+      className={`education-section${className ? ` ${className}` : ''}`}
+      ref={containerRef}
+    >
       <h2 className="cv-section-title">Education</h2>
       {education.map((edu, index) => (
-        <details key={index} className="cv-card cv-collapse">
+        <details
+          key={index}
+          className={`cv-card cv-collapse${isActive(index) ? ' is-active' : ''}`}
+        >
           <summary className="cv-collapse-summary">
             <div className="education-header">
               <h3>{edu.degree}</h3>

--- a/src/components/cv/CVExperienceSection.tsx
+++ b/src/components/cv/CVExperienceSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useScrollSpy } from '../../lib/hooks';
 import { ExperienceItem } from '../../types';
 
 interface CVExperienceSectionProps {
@@ -10,13 +11,21 @@ const CVExperienceSection: React.FC<CVExperienceSectionProps> = ({
   experiences,
   className,
 }) => {
+  const { containerRef, isActive } = useScrollSpy<HTMLElement>(
+    'details.cv-collapse'
+  );
+
   return (
     <section
       className={`experience-section${className ? ` ${className}` : ''}`}
+      ref={containerRef}
     >
       <h2 className="cv-section-title">Experience</h2>
       {experiences.map((exp, index) => (
-        <details key={index} className="cv-card cv-collapse">
+        <details
+          key={index}
+          className={`cv-card cv-collapse${isActive(index) ? ' is-active' : ''}`}
+        >
           <summary className="cv-collapse-summary">
             <div className="experience-header">
               <h3>

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -35,17 +35,24 @@ const LayoutInner: React.FC<LayoutProps> = ({ children }) => {
   }, []);
 
   React.useEffect(() => {
-    const handleScroll = () => {
-      if (typeof window !== 'undefined') {
-        // Apply blur when scrolled more than 50px
-        setIsScrolled(window.scrollY > 50);
-      }
+    if (typeof window === 'undefined') return;
+
+    // The page scrolls inside `.layout`, not the window, so `window.scrollY`
+    // stays at 0 and this never fired. Scroll events do not bubble either —
+    // capturing on the document catches the one from the panel.
+    const handleScroll = (event: Event) => {
+      const target = event.target as HTMLElement | Document | null;
+      const top =
+        target instanceof HTMLElement ? target.scrollTop : window.scrollY;
+      setIsScrolled(top > 50);
     };
 
-    if (typeof window !== 'undefined') {
-      window.addEventListener('scroll', handleScroll);
-      return () => window.removeEventListener('scroll', handleScroll);
-    }
+    document.addEventListener('scroll', handleScroll, {
+      capture: true,
+      passive: true,
+    });
+    return () =>
+      document.removeEventListener('scroll', handleScroll, { capture: true });
   }, []);
 
   // Determine CSS classes based on panel states

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -1,2 +1,3 @@
 // Custom React hooks barrel exports
+export { useScrollSpy } from './useScrollSpy';
 export { useTheme } from './useTheme';

--- a/src/lib/hooks/useScrollSpy.ts
+++ b/src/lib/hooks/useScrollSpy.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const NONE: readonly number[] = [];
+
+interface ScrollSpyOptions {
+  /**
+   * How far down the viewport the reading line sits, as a fraction of its
+   * height. A little above centre, so a card lights up as you arrive at it
+   * rather than once it has already gone past.
+   */
+  readingLine?: number;
+}
+
+/**
+ * Reports which items in a list are sitting at the reading line, so a list can
+ * highlight itself as the page scrolls rather than holding on to whatever the
+ * last tap left behind. Works in both directions — the answer is recomputed
+ * from geometry every frame that moves, not accumulated from scroll direction.
+ *
+ * Ties light up together, which is what keeps a multi-column grid from picking
+ * one arbitrary cell out of a row that is all equally under the line.
+ */
+export function useScrollSpy<T extends HTMLElement>(
+  itemSelector: string,
+  { readingLine = 0.4 }: ScrollSpyOptions = {}
+) {
+  const containerRef = useRef<T | null>(null);
+  const [activeIndices, setActiveIndices] = useState<readonly number[]>(NONE);
+
+  const measure = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const items = Array.from(container.querySelectorAll(itemSelector));
+    const viewportHeight = window.innerHeight;
+    const line = viewportHeight * readingLine;
+
+    let closest = Infinity;
+    const distances = items.map(item => {
+      const { top, bottom } = item.getBoundingClientRect();
+      // Items that have scrolled out never win, however near their edge is.
+      if (bottom <= 0 || top >= viewportHeight) return Infinity;
+      // Zero while the line is inside the item; otherwise the gap to it.
+      const distance = Math.round(Math.max(top - line, line - bottom, 0));
+      if (distance < closest) closest = distance;
+      return distance;
+    });
+
+    setActiveIndices(previous => {
+      if (closest === Infinity) {
+        // Nothing in view: drop the highlight rather than stranding it on the
+        // last item, which would otherwise stay lit for the rest of the page.
+        return previous.length === 0 ? previous : NONE;
+      }
+
+      const next: number[] = [];
+      distances.forEach((distance, index) => {
+        if (distance === closest) next.push(index);
+      });
+
+      const unchanged =
+        next.length === previous.length &&
+        next.every((index, i) => index === previous[i]);
+      return unchanged ? previous : next;
+    });
+  }, [itemSelector, readingLine]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    let frame = 0;
+    const schedule = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = 0;
+        measure();
+      });
+    };
+
+    // The page scrolls inside `.layout`, not the window, and scroll events do
+    // not bubble — capturing on the document catches them wherever they start.
+    const scrollOptions = { capture: true, passive: true } as const;
+    document.addEventListener('scroll', schedule, scrollOptions);
+    window.addEventListener('resize', schedule);
+
+    // Filtering a list, expanding a card, or a webfont landing all move items
+    // without a scroll, so watch the container's own geometry as well.
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined'
+        ? null
+        : new ResizeObserver(schedule);
+    if (resizeObserver && containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    measure();
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      document.removeEventListener('scroll', schedule, { capture: true });
+      window.removeEventListener('resize', schedule);
+      resizeObserver?.disconnect();
+    };
+  }, [measure]);
+
+  const isActive = useCallback(
+    (index: number) => activeIndices.includes(index),
+    [activeIndices]
+  );
+
+  return { containerRef, activeIndices, isActive };
+}
+
+export default useScrollSpy;

--- a/src/pages/blog.tsx
+++ b/src/pages/blog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { graphql, Link } from 'gatsby';
 import { Layout, SEO } from '../components';
+import { useScrollSpy } from '../lib/hooks';
 import { BlogPageProps } from '../types';
 import '../styles/blog.scss';
 
@@ -52,6 +53,11 @@ const BlogPage: React.FC<BlogPageProps> = ({ data }) => {
       return sortOrder === 'desc' ? dateB - dateA : dateA - dateB;
     });
   }, [allPosts, searchTerm, selectedCategory, sortOrder]);
+
+  // Marks whichever post is at the reading position, so the list tracks the
+  // scroll the same way the expertise grid and the CV entries do.
+  const { containerRef: postsRef, isActive: isPostActive } =
+    useScrollSpy<HTMLDivElement>('.post-preview');
 
   const clearFilters = () => {
     setSearchTerm('');
@@ -139,9 +145,14 @@ const BlogPage: React.FC<BlogPageProps> = ({ data }) => {
               </p>
             </div>
           ) : (
-            <div className="posts-list">
-              {filteredPosts.map(post => (
-                <article key={post.id} className="post-preview">
+            <div className="posts-list" ref={postsRef}>
+              {filteredPosts.map((post, index) => (
+                <article
+                  key={post.id}
+                  className={`post-preview${
+                    isPostActive(index) ? ' is-active' : ''
+                  }`}
+                >
                   <div className="post-meta">
                     <time dateTime={post.frontmatter.date}>
                       {new Date(post.frontmatter.date).toLocaleDateString(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Layout, SEO } from '../components';
 import { getCTAButtonURL, homepageConfig } from '../config';
+import { useScrollSpy } from '../lib/hooks';
 import developmentIcon from '../images/development.png';
 import gearIcon from '../images/gear.png';
 import observabilityIcon from '../images/observability.png';
@@ -10,6 +11,11 @@ import systemsIcon from '../images/systems.png';
 import '../styles/index.scss';
 
 const IndexPage: React.FC = () => {
+  // The grid used to sit lit up wherever a tap left it, on cards that go
+  // nowhere when clicked. Reading position drives the highlight instead.
+  const { containerRef: expertiseRef, isActive: isExpertiseActive } =
+    useScrollSpy<HTMLDivElement>('.expertise-item');
+
   return (
     <Layout>
       <SEO
@@ -81,7 +87,7 @@ const IndexPage: React.FC = () => {
 
         <section className="expertise">
           <h2>{homepageConfig.expertise.title}</h2>
-          <div className="expertise-grid">
+          <div className="expertise-grid" ref={expertiseRef}>
             {homepageConfig.expertise.items.map((item, index) => {
               const expertiseImages = [
                 systemsIcon, // ai system architecture
@@ -93,7 +99,12 @@ const IndexPage: React.FC = () => {
               ];
               const iconSrc = expertiseImages[index] ?? developmentIcon;
               return (
-                <div key={index} className="expertise-item">
+                <div
+                  key={index}
+                  className={`expertise-item${
+                    isExpertiseActive(index) ? ' is-active' : ''
+                  }`}
+                >
                   <span className="expertise-icon">
                     <img src={iconSrc} alt={item.title} />
                   </span>

--- a/src/styles/404.scss
+++ b/src/styles/404.scss
@@ -1,3 +1,8 @@
+@import 'variables';
+@import 'mixins';
+
+// This page has no card of its own — it sits straight on the animated
+// background in both themes, so both lines carry the halo.
 .not-found {
   text-align: center;
   padding: 4rem 2rem;
@@ -7,11 +12,14 @@
   h1 {
     font-size: 3rem;
     margin-bottom: 1rem;
+    color: var(--text-primary);
+    @include over-background;
   }
 
   p {
     font-size: 1.2rem;
     color: var(--text-secondary);
+    @include over-background;
     margin-bottom: 2rem;
   }
 }
@@ -24,7 +32,7 @@
     var(--primary-color),
     var(--secondary-color)
   );
-  color: white;
+  color: var(--on-fill);
   text-decoration: none;
   border-radius: var(--radius-lg);
   font-weight: 600;
@@ -51,16 +59,16 @@
   }
 }
 
-// Light mode - text on dark background
+// The stage behind the backgrounds is dark in both themes, so the light theme
+// only needs the same white the dark theme already uses.
 [data-theme='light'] {
   .not-found {
     h1 {
       color: white;
-      text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
     }
 
     p {
-      color: rgba(255, 255, 255, 0.8);
+      color: rgba(255, 255, 255, 0.9);
     }
   }
 }

--- a/src/styles/animated-backgrounds.scss
+++ b/src/styles/animated-backgrounds.scss
@@ -1,5 +1,21 @@
 // Animated backgrounds styles using design system variables
 
+// The simulations render into a canvas that sits at 90% opacity, so whatever is
+// behind it shows through and becomes part of the picture. Letting that be the
+// theme's page colour is what made the set look inconsistent between themes:
+// against the light theme's near-white base the sparse backgrounds — the
+// cellular automaton, the graph — washed out into pale fields, while the dense
+// ones — the PDE solver, the spectrogram — barely moved. Pinning it to one
+// constant near-black in both themes is what makes the six read as one set, and
+// it is what the white chrome layered over them already assumes.
+.background-stage {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background: var(--bg-stage);
+}
+
 // Background controls container (bottom-left)
 .background-controls {
   position: fixed;
@@ -57,13 +73,14 @@
     gap: 0.5rem;
     padding: 0.75rem 1rem;
     position: relative; // anchor tooltips and nav buttons to toolbar
-    background: var(--bg-secondary);
-    border: 1px solid var(--border-color);
+    // Floating surface, not a page surface: this sits over whichever
+    // background is running, so it takes the opaque floating tone rather than
+    // the near-clear control tint, which let the background read through it.
+    background: var(--bg-floating);
+    border: 1px solid var(--border-floating);
     border-radius: var(--radius-lg);
     color: var(--text-primary);
     font-size: 0.875rem;
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px); // Safari 17 and earlier
     box-shadow: var(--shadow-lg);
     transition: all var(--transition-normal);
     min-width: 280px; // Match keyboard hints width for alignment
@@ -86,7 +103,7 @@
     }
 
     .background-name {
-      color: var(--primary-color);
+      color: var(--ink-primary);
       font-weight: 600;
       font-size: 0.875rem;
       text-align: center;
@@ -95,20 +112,28 @@
 
   .keyboard-hint {
     font-size: 0.6875rem;
-    color: var(--text-muted);
+    // Sits on the animated background with no surface under it, so it takes
+    // the halo rather than relying on the background staying dark.
+    color: var(--text-secondary);
+    @include over-background;
     text-align: left;
-    opacity: 0.6;
+    opacity: 0.85;
     font-family: inherit;
     width: 280px; // Fixed width to prevent jumping
 
+    // No surface behind these either, so the key caps carry their own rather
+    // than borrowing the page's — --bg-accent is a 3%-to-5% wash that simply
+    // disappears against the background.
     kbd {
-      background: var(--bg-accent);
-      border: 1px solid var(--border-color);
+      background: var(--bg-floating);
+      border: 1px solid var(--border-floating);
       border-radius: var(--radius-sm);
       padding: 0.125rem 0.25rem;
       margin: 0 0.125rem;
       font-size: 0.625rem;
       font-family: inherit;
+      color: var(--text-primary);
+      text-shadow: none;
     }
   }
 }
@@ -169,7 +194,7 @@
         margin-bottom: 0.75rem;
 
         .background-name {
-          color: var(--primary-color);
+          color: var(--ink-primary);
           font-weight: 600;
           font-size: 1rem; // Match chat panel font sizing
         }
@@ -223,7 +248,7 @@
         display: inline-flex;
         align-items: center;
         gap: 0.375rem;
-        color: var(--primary-color);
+        color: var(--ink-primary);
         text-decoration: none;
         font-size: 0.75rem;
         font-weight: 500;
@@ -258,7 +283,7 @@
         .special-hotkeys-title {
           font-size: 0.75rem;
           font-weight: 600;
-          color: var(--primary-color);
+          color: var(--ink-primary);
           margin-bottom: 0.5rem;
           font-family: inherit;
           letter-spacing: 0.5px;
@@ -328,7 +353,7 @@
             &.active {
               background: rgba(0, 255, 136, 0.2);
               border-color: var(--primary-color);
-              color: var(--primary-color);
+              color: var(--ink-primary);
               transform: translateY(0);
 
               kbd {
@@ -399,7 +424,7 @@
 
       &.open {
         background: var(--bg-accent);
-        color: var(--primary-color);
+        color: var(--ink-primary);
         border-left: 2px solid var(--primary-color);
       }
 
@@ -433,7 +458,7 @@
 
       &.open .category-toggle {
         transform: rotate(90deg); // down
-        color: var(--primary-color);
+        color: var(--ink-primary);
       }
     }
 
@@ -684,7 +709,7 @@
           margin-right: 0.5rem;
           font-size: 0.625rem;
           font-family: inherit;
-          color: var(--primary-color);
+          color: var(--ink-primary);
         }
       }
     }
@@ -719,20 +744,22 @@
       justify-content: center;
       gap: 0.25rem;
       font-size: 0.6875rem;
-      color: var(--text-muted);
-      opacity: 0.7; // Slightly more visible
+      color: var(--text-secondary);
+      opacity: 0.9;
       font-family: inherit;
       padding-top: 0.5rem;
 
+      // Key caps were a white wash on a white border, which only ever showed
+      // up on the dark panel; on the light theme's they vanished entirely.
       kbd {
-        background: rgba(255, 255, 255, 0.06);
-        border: 1px solid rgba(255, 255, 255, 0.1);
+        background: var(--bg-accent);
+        border: 1px solid var(--border-color);
         border-radius: var(--radius-sm);
         padding: 0.125rem 0.3rem;
         font-size: 0.625rem;
         font-family: inherit;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-        color: var(--primary-color);
+        color: var(--ink-primary);
       }
     }
   }
@@ -782,7 +809,7 @@
   line-height: 1;
 
   &:hover {
-    color: var(--primary-color);
+    color: var(--ink-primary);
     background: var(--bg-accent);
   }
 }
@@ -1102,7 +1129,7 @@
       transition: all var(--transition-fast);
 
       &.open {
-        color: var(--primary-color);
+        color: var(--ink-primary);
         border-color: var(--primary-color);
       }
     }

--- a/src/styles/animations.scss
+++ b/src/styles/animations.scss
@@ -1,11 +1,20 @@
 // Animation keyframes and utilities
 
+// Every page title that glows sits directly on the animated background, so the
+// legibility halo has to ride along inside the keyframes: an animated
+// text-shadow replaces the static one outright, which is why the dark halos
+// written next to these rules never actually rendered.
 @keyframes glow {
   from {
-    text-shadow: 0 0 20px rgba(0, 255, 136, 0.3);
+    text-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.9),
+      0 0 12px rgba(0, 0, 0, 0.6),
+      0 0 20px rgba(0, 255, 136, 0.3);
   }
   to {
     text-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.9),
+      0 0 12px rgba(0, 0, 0, 0.6),
       0 0 30px rgba(0, 255, 136, 0.6),
       0 0 40px rgba(0, 255, 136, 0.3);
   }

--- a/src/styles/blog.scss
+++ b/src/styles/blog.scss
@@ -32,6 +32,7 @@
 
   p {
     color: var(--text-secondary);
+    @include over-background;
     font-size: 1.1rem;
     line-height: 1.6;
     font-style: italic;
@@ -144,9 +145,9 @@
           background: linear-gradient(
             135deg,
             var(--accent-pink),
-            var(--accent-purple)
+            var(--fill-purple)
           );
-          color: white;
+          color: var(--on-fill);
           border-color: transparent;
           box-shadow: 0 0 15px rgba(255, 0, 128, 0.4);
         }
@@ -219,7 +220,7 @@
 
       &.active {
         border-color: var(--accent-pink);
-        color: var(--accent-pink);
+        color: var(--ink-pink);
 
         &:hover {
           box-shadow: 0 0 10px rgba(255, 0, 128, 0.2);
@@ -284,11 +285,22 @@
     border-radius: var(--radius-sm) 0 0 var(--radius-sm);
   }
 
-  &:hover {
+  @include reading-emphasis {
     background: var(--bg-hover);
-    transform: translateY(-2px);
     box-shadow: 0 0 20px rgba(0, 212, 255, 0.1);
     border-color: var(--border-active);
+
+    // The rail is the quiet marker of which post you are on; it goes from a
+    // flat tint to the full gradient rather than appearing out of nothing.
+    &::before {
+      width: 4px;
+    }
+  }
+
+  @include hover-lift;
+
+  &::before {
+    transition: width var(--transition-normal);
   }
 }
 
@@ -306,8 +318,8 @@
 }
 
 .post-category {
-  background: linear-gradient(135deg, var(--accent-pink), var(--accent-purple));
-  color: white;
+  background: linear-gradient(135deg, var(--accent-pink), var(--fill-purple));
+  color: var(--on-fill);
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-sm);
   font-size: 0.8rem;
@@ -333,7 +345,7 @@
     transition: color var(--transition-fast);
 
     &:hover {
-      color: var(--primary-color);
+      color: var(--ink-primary);
     }
   }
 }
@@ -352,7 +364,7 @@
 }
 
 .read-more {
-  color: var(--primary-color);
+  color: var(--ink-primary);
   text-decoration: none;
   font-weight: 500;
   font-family:
@@ -362,7 +374,7 @@
   transition: all var(--transition-fast);
 
   &:hover {
-    color: var(--primary-dark);
+    color: var(--ink-primary);
     text-decoration: underline;
     text-shadow: 0 0 10px rgba(0, 255, 136, 0.5);
   }
@@ -500,7 +512,7 @@
     border-radius: var(--radius-sm);
     font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
     font-size: 0.9rem;
-    color: var(--accent-cyan);
+    color: var(--ink-cyan);
     border: 1px solid var(--border-color);
   }
 
@@ -538,13 +550,13 @@
   }
 
   a {
-    color: var(--accent-blue);
+    color: var(--ink-blue);
     text-decoration: none;
     font-weight: 500;
     transition: all var(--transition-fast);
 
     &:hover {
-      color: var(--accent-cyan);
+      color: var(--ink-cyan);
       text-decoration: underline;
       text-shadow: 0 0 10px rgba(0, 212, 255, 0.5);
     }
@@ -611,14 +623,17 @@
   border-top: 1px solid var(--border-color);
 }
 
+// Below the post card, so it sits on the background: white with a halo rather
+// than the green ink, which is tuned for a white card and disappears here.
 .back-to-blog {
-  color: var(--primary-color);
+  color: white;
+  @include over-background;
   text-decoration: none;
   font-weight: 500;
   transition: all var(--transition-fast);
 
   &:hover {
-    color: var(--primary-dark);
+    color: var(--primary-color);
     text-decoration: underline;
   }
 }
@@ -745,7 +760,7 @@
 
       &.active {
         background: var(--accent-blue);
-        color: white;
+        color: var(--on-fill);
         box-shadow: 0 2px 10px rgba(33, 150, 243, 0.3);
       }
     }
@@ -772,7 +787,7 @@
       );
     }
 
-    &:hover {
+    @include reading-emphasis {
       box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
       border-color: var(--accent-cyan);
     }
@@ -782,7 +797,7 @@
       color: var(--text-primary);
 
       &:hover {
-        color: var(--accent-blue);
+        color: var(--ink-blue);
       }
     }
 
@@ -793,24 +808,24 @@
     }
 
     .read-more {
-      color: var(--accent-blue);
+      color: var(--ink-blue);
 
       &:hover {
-        color: var(--accent-pink);
+        color: var(--ink-pink);
       }
     }
   }
 
   .post-category {
     background: var(--accent-blue);
-    color: white;
+    color: var(--on-fill);
     box-shadow: 0 2px 6px rgba(33, 150, 243, 0.3);
   }
 
   .post-content {
     code {
       background: var(--bg-hover);
-      color: var(--accent-blue);
+      color: var(--ink-blue);
       border: 1px solid var(--border-color);
     }
 
@@ -830,10 +845,10 @@
     }
 
     a {
-      color: var(--accent-blue);
+      color: var(--ink-blue);
 
       &:hover {
-        color: var(--accent-pink);
+        color: var(--ink-pink);
         text-shadow: 0 0 6px rgba(233, 30, 99, 0.3);
       }
     }

--- a/src/styles/chat.scss
+++ b/src/styles/chat.scss
@@ -29,10 +29,10 @@
     flex-direction: column;
     gap: 0.5rem;
     padding: 0.75rem 1rem;
-    background: var(--bg-secondary, rgba(0, 0, 0, 0.1));
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    border: 1px solid var(--border-color);
+    // Matches the background toolbar in the opposite corner — both float over
+    // the animated background rather than sitting on a page surface.
+    background: var(--bg-floating);
+    border: 1px solid var(--border-floating);
     border-radius: var(--radius-lg);
     color: var(--text-primary);
     font-size: 0.875rem;
@@ -56,7 +56,7 @@
       align-items: center;
       justify-content: center;
       gap: 0.5rem;
-      color: var(--primary-color);
+      color: var(--ink-primary);
 
       svg {
         flex-shrink: 0;
@@ -71,20 +71,23 @@
 
   .keyboard-hint {
     font-size: 0.6875rem;
-    color: var(--text-muted);
+    color: var(--text-secondary);
+    @include over-background;
     text-align: right;
-    opacity: 0.6;
+    opacity: 0.85;
     font-family: inherit;
     width: 280px;
 
     kbd {
-      background: var(--bg-accent, rgba(255, 255, 255, 0.03));
-      border: 1px solid var(--border-color);
+      background: var(--bg-floating);
+      border: 1px solid var(--border-floating);
       border-radius: var(--radius-sm);
       padding: 0.125rem 0.25rem;
       margin: 0 0.125rem;
       font-size: 0.625rem;
       font-family: inherit;
+      color: var(--text-primary);
+      text-shadow: none;
     }
   }
 }
@@ -232,7 +235,7 @@
     overflow: visible;
 
     .chat-title {
-      color: var(--primary-color);
+      color: var(--ink-primary);
       font-size: 1.1rem;
       font-weight: 600;
       margin: 0;
@@ -278,11 +281,11 @@
         }
 
         &.enabled {
-          color: var(--primary-color);
+          color: var(--ink-primary);
 
           &:hover {
             background: rgba(139, 92, 246, 0.1);
-            color: var(--primary-color);
+            color: var(--ink-primary);
             border-color: var(--border-active);
           }
         }
@@ -471,7 +474,7 @@
         &:hover:not(:disabled) {
           background: var(--bg-accent);
           border-color: var(--primary-color);
-          color: var(--primary-color);
+          color: var(--ink-primary);
           transform: translateY(-1px);
           box-shadow: var(--shadow-md);
         }
@@ -530,7 +533,7 @@
         font-size: 0.625rem;
         font-family: inherit;
         box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-        color: var(--primary-color);
+        color: var(--ink-primary);
       }
     }
   }
@@ -1332,7 +1335,7 @@
       line-height: 1.5;
 
       strong {
-        color: var(--primary-color);
+        color: var(--ink-primary);
         font-weight: 500;
       }
     }
@@ -2064,7 +2067,7 @@
             display: inline-flex;
             align-items: center;
             gap: 0.375rem;
-            color: var(--primary-color);
+            color: var(--ink-primary);
             text-decoration: none;
             font-size: 0.75rem;
             font-weight: 500;
@@ -2203,7 +2206,7 @@
   // Code
   .markdown-code-inline {
     background: var(--bg-accent);
-    color: var(--primary-color);
+    color: var(--ink-primary);
     padding: 0.125rem 0.375rem;
     border-radius: var(--radius-sm);
     font-family: 'JetBrains Mono', 'Fira Code', monospace;
@@ -2235,7 +2238,7 @@
 
   // Links
   .markdown-link {
-    color: var(--primary-color);
+    color: var(--ink-primary);
     text-decoration: none;
     border-bottom: 1px solid transparent;
     transition: border-color var(--transition-fast);
@@ -2245,7 +2248,7 @@
     }
 
     &:visited {
-      color: var(--primary-color);
+      color: var(--ink-primary);
       opacity: 0.8;
     }
   }
@@ -2360,7 +2363,7 @@
       }
 
       &:hover {
-        color: var(--primary-color);
+        color: var(--ink-primary);
         background: var(--bg-hover);
         transform: translateY(0);
       }
@@ -2370,7 +2373,7 @@
       }
 
       &[title='Copied!'] {
-        color: var(--primary-color);
+        color: var(--ink-primary);
         opacity: 1;
       }
     }

--- a/src/styles/cv.scss
+++ b/src/styles/cv.scss
@@ -1,3 +1,6 @@
+@import 'variables';
+@import 'mixins';
+
 .cv {
   max-width: 900px;
   margin: 0 auto;
@@ -49,6 +52,7 @@ section[id] {
 
   p {
     color: var(--text-secondary);
+    @include over-background;
     font-size: 1.1rem;
     line-height: 1.6;
     font-style: italic;
@@ -114,7 +118,7 @@ section[id] {
   }
 
   li.active a {
-    color: var(--primary-color);
+    color: var(--ink-primary);
     background: var(--bg-accent);
     border-color: var(--primary-color);
   }
@@ -223,7 +227,7 @@ section[id] {
         transition: color var(--transition-fast);
 
         &:hover {
-          color: var(--primary-color);
+          color: var(--ink-primary);
         }
       }
     }
@@ -289,8 +293,12 @@ section[id] {
   }
 }
 
-// New section title style for direct layout
+// Section titles sit on the animated background, not on a card — so they are
+// white with a halo in both themes. Following --text-primary put them at
+// #212121 in the light theme, which is invisible against the dark stage.
 .cv-section-title {
+  color: white;
+  @include over-background;
   font-size: 1.8rem;
   margin-bottom: 1.5rem;
   padding-bottom: 0.5rem;
@@ -302,7 +310,6 @@ section[id] {
   text-transform: lowercase;
   letter-spacing: -0.02em;
   position: relative;
-  color: var(--text-primary);
 }
 
 // Shared card style for experience, education, and certifications
@@ -334,8 +341,7 @@ section[id] {
     opacity: 0.5;
   }
 
-  &:hover {
-    transform: translateY(-2px);
+  @include reading-emphasis {
     box-shadow: 0 4px 20px rgba(0, 255, 136, 0.1);
     border-color: var(--border-active);
 
@@ -343,6 +349,8 @@ section[id] {
       opacity: 1;
     }
   }
+
+  @include hover-lift;
 }
 
 .experience-item {
@@ -391,29 +399,95 @@ section[id] {
   }
 }
 
-// Remove accent top line for collapsible cards
+// Collapsible cards trade the top gradient hairline for a left rail, the same
+// marker `.about` and the blog previews use. It reads as a state, not an
+// ornament: flat while the card is just sitting there, brighter for whichever
+// entry the scroll has arrived at, and full accent once the entry is open.
 .cv-card.cv-collapse::before {
-  content: none !important;
-  display: none !important;
-  background: none !important;
-  height: 0 !important;
+  content: '';
+  top: 0;
+  right: auto;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  height: auto;
+  border-radius: 0;
+  background: var(--border-color);
+  opacity: 1;
+  transition:
+    background var(--transition-normal),
+    width var(--transition-normal);
 }
 
+.cv-collapse.is-active::before {
+  background: var(--border-active);
+}
+
+.cv-collapse[open] {
+  border-color: var(--border-active);
+
+  &::before {
+    width: 4px;
+    background: linear-gradient(
+      180deg,
+      var(--accent-cyan) 0%,
+      var(--primary-color) 100%
+    );
+  }
+}
+
+// The whole summary is the toggle — it fills the collapsed card edge to edge —
+// so it has to look like it, rather than leaving the chevron as the only cue.
 .cv-collapse-summary {
   padding: 1.25rem 1.5rem;
   cursor: pointer;
   display: block;
+  transition: background var(--transition-fast);
+
+  // Clipped by the card's overflow, so the ring goes inside rather than being
+  // sliced into a stray line along the bottom edge.
+  &:focus-visible {
+    outline-offset: -4px;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background: var(--bg-hover);
+    }
+  }
 
   .summary-right {
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
 
   .cv-collapse-chevron {
-    transition: transform var(--transition-normal);
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1.75rem;
+    height: 1.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 0.7rem;
+    line-height: 1;
+    transition: all var(--transition-normal);
   }
+}
+
+.cv-collapse.is-active .cv-collapse-chevron,
+.cv-collapse-summary:hover .cv-collapse-chevron {
+  border-color: var(--border-active);
+  color: var(--text-primary);
+}
+
+.cv-collapse[open] .cv-collapse-chevron {
+  border-color: var(--accent-cyan);
+  color: var(--ink-cyan);
 }
 
 // Collapsed institution line style
@@ -449,8 +523,13 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
   }
 }
 
+// Separator between the summary and what it opens. Inset from the card edges
+// so it reads as a divider rather than a seam, and with the same buffer above
+// and below the rule as the summary keeps under its own last line.
 .cv-collapse-details {
-  padding: 0 1.5rem 1.25rem 1.5rem;
+  margin: 0 1.5rem;
+  padding: 1.5rem 0 1.75rem;
+  border-top: 1px solid var(--border-color);
 }
 
 .experience-duration {
@@ -473,7 +552,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     position: relative;
 
     &::marker {
-      color: var(--primary-color);
+      color: var(--ink-primary);
     }
   }
 }
@@ -521,8 +600,8 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
   display: inline-flex;
   align-items: center;
   padding: 0.6rem 1.2rem;
-  background: linear-gradient(135deg, var(--accent-purple), var(--accent-pink));
-  color: white;
+  background: linear-gradient(135deg, var(--fill-purple), var(--accent-pink));
+  color: var(--on-fill);
   border-radius: var(--radius-md);
   font-size: 0.925rem;
   font-weight: 500;
@@ -703,7 +782,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
       font-size: 0.9rem;
 
       a {
-        color: var(--primary-color);
+        color: var(--ink-primary);
         text-decoration: none;
 
         &:hover {
@@ -748,7 +827,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     position: relative;
 
     &::marker {
-      color: var(--primary-color);
+      color: var(--ink-primary);
     }
   }
 }
@@ -827,7 +906,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     position: relative;
 
     &::marker {
-      color: var(--primary-color);
+      color: var(--ink-primary);
     }
   }
 }
@@ -836,10 +915,13 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 .skill-category-direct {
   margin-bottom: 1.5rem;
 
+  // On the background alongside the chips rather than on a card, so it takes
+  // the same treatment as the section titles above it.
   .skill-subtitle {
     font-size: 1.2rem;
     margin-bottom: 1rem;
-    color: var(--text-primary);
+    color: white;
+    @include over-background;
     font-family:
       'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
       monospace;
@@ -864,7 +946,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
   &.technical {
     background: linear-gradient(135deg, var(--accent-cyan), var(--accent-blue));
-    color: white;
+    color: var(--on-fill);
     border: 1px solid transparent;
   }
 
@@ -874,17 +956,13 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
       var(--primary-color),
       var(--accent-cyan)
     );
-    color: white;
+    color: var(--on-fill);
     border: 1px solid transparent;
   }
 
   &.language {
-    background: linear-gradient(
-      135deg,
-      var(--accent-pink),
-      var(--accent-purple)
-    );
-    color: white;
+    background: linear-gradient(135deg, var(--accent-pink), var(--fill-purple));
+    color: var(--on-fill);
     border: 1px solid transparent;
   }
 
@@ -994,7 +1072,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
         .result-type {
           font-size: 0.8rem;
           font-weight: 500;
-          color: var(--accent-color);
+          color: var(--ink-pink);
           font-family:
             'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
             monospace;
@@ -1045,6 +1123,11 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     border: 2px solid transparent;
     border-radius: var(--radius-md);
     font-weight: 500;
+    // Stated rather than inherited: the pdf button is an <a> at a prebuilt
+    // artifact while the other two are <button>s, so without this they sit at
+    // 1rem and the UA's 13.33px respectively, side by side in the same row.
+    font-size: 0.9rem;
+    line-height: 1.2;
     font-family:
       'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
       monospace;
@@ -1088,7 +1171,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
     &.pdf {
       background: var(--primary-color);
-      color: white;
+      color: var(--on-fill);
       border-color: var(--primary-color);
 
       &:hover:not(:disabled) {
@@ -1107,7 +1190,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
     &.docx {
       background: var(--secondary-color);
-      color: white;
+      color: var(--on-fill);
       border-color: var(--secondary-color);
 
       &:hover:not(:disabled) {
@@ -1199,11 +1282,11 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
       border-radius: var(--radius-sm);
       font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
       font-size: 0.85rem;
-      color: var(--primary-color);
+      color: var(--ink-primary);
     }
 
     a {
-      color: var(--primary-color);
+      color: var(--ink-primary);
       text-decoration: none;
 
       &:hover {
@@ -1485,7 +1568,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
     .contact-value {
       &:hover {
-        color: var(--accent-blue);
+        color: var(--ink-blue);
       }
     }
   }
@@ -1561,26 +1644,26 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     }
   }
 
+  // No card here: the chips are the content, and certifications right below it
+  // has never had one either. Carding only this one, and only in this theme,
+  // was the odd one out.
   .skills-section {
-    background: var(--bg-card);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-
     .skill-tag {
       &.technical {
         background: var(--accent-cyan);
-        color: white;
+        color: var(--on-fill);
         box-shadow: 0 2px 6px rgba(0, 172, 193, 0.3);
       }
 
       &.soft {
         background: var(--primary-color);
-        color: white;
+        color: var(--on-fill);
         box-shadow: 0 2px 6px rgba(0, 168, 84, 0.3);
       }
 
       &.language {
         background: var(--accent-pink);
-        color: white;
+        color: var(--on-fill);
         box-shadow: 0 2px 6px rgba(233, 30, 99, 0.3);
       }
 
@@ -1593,10 +1676,10 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     .certification-chip {
       background: linear-gradient(
         135deg,
-        var(--accent-purple),
+        var(--fill-purple),
         var(--accent-pink)
       );
-      color: white;
+      color: var(--on-fill);
       box-shadow: 0 2px 8px rgba(147, 51, 234, 0.3);
 
       &:hover {
@@ -1679,7 +1762,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
 
       code {
         background: var(--bg-card);
-        color: var(--accent-blue);
+        color: var(--ink-blue);
         border: 1px solid var(--border-color);
       }
     }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -89,12 +89,12 @@ body {
 }
 
 a {
-  color: var(--primary-color);
+  color: var(--ink-primary);
   text-decoration: none;
   transition: color var(--transition-fast);
 
   &:hover {
-    color: var(--primary-dark);
+    color: var(--ink-primary);
   }
 }
 
@@ -200,16 +200,19 @@ img {
 /* Selection styling */
 ::selection {
   background: var(--primary-color);
-  color: white;
+  color: var(--on-fill);
 }
 
 [data-theme='light'] ::selection {
   background: var(--accent-blue);
-  color: white;
+  color: var(--on-fill);
 }
 
-/* Focus styles */
-*:focus {
+/* Focus styles. :focus-visible rather than :focus, so the ring answers the
+   keyboard and does not fire on every mouse click — on the CV's collapsible
+   cards a clicked <summary> kept its ring, which the card's overflow clipped
+   into a stray rule sitting right on top of the content it had just opened. */
+*:focus-visible {
   outline: 2px solid var(--primary-color);
   outline-offset: 2px;
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -26,6 +26,7 @@
 .hero-subtitle {
   font-size: 1.25rem;
   color: var(--text-secondary);
+  @include over-background;
   line-height: 1.6;
   max-width: 600px;
   margin: 0 auto;
@@ -141,8 +142,10 @@
 .expertise {
   margin-bottom: 4rem;
 
+  // Sits on the animated background, not in a card, in both themes.
   h2 {
     margin-bottom: 2rem;
+    @include over-background;
   }
 }
 
@@ -196,16 +199,22 @@
     background: var(--accent-yellow);
   }
 
-  &:hover {
+  @include reading-emphasis {
     background: var(--bg-hover);
     border-color: var(--border-active);
-    transform: translateY(-2px);
     box-shadow: 0 0 20px rgba(0, 255, 136, 0.1);
 
     &::before {
       transform: scaleX(1);
     }
+
+    .expertise-icon {
+      opacity: 1;
+      transform: scale(1.1);
+    }
   }
+
+  @include hover-lift;
 
   .expertise-icon {
     font-size: 2.5rem;
@@ -225,11 +234,6 @@
         opacity var(--transition-normal),
         filter var(--transition-normal);
     }
-  }
-
-  &:hover .expertise-icon {
-    opacity: 1;
-    transform: scale(1.1);
   }
 
   // Dark mode image inversion for expertise icons (black line PNGs -> white lines)
@@ -276,12 +280,13 @@
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   }
 
-  &:hover {
+  @include reading-emphasis {
     background: var(--bg-hover);
-    transform: translateY(-2px);
     box-shadow: 0 0 20px rgba(255, 0, 255, 0.1);
     border-color: var(--border-active);
   }
+
+  @include hover-lift;
 
   h2 {
     margin-bottom: 1.5rem;
@@ -307,13 +312,13 @@
     font-style: italic;
 
     a {
-      color: var(--accent-pink);
+      color: var(--ink-pink);
       text-decoration: none;
       font-weight: 500;
       transition: all var(--transition-fast);
 
       &:hover {
-        color: var(--accent-blue);
+        color: var(--ink-blue);
         text-decoration: underline;
         text-shadow: 0 0 10px rgba(0, 128, 255, 0.5);
       }
@@ -375,10 +380,6 @@
 
   .expertise-item {
     padding: 1.5rem 1rem;
-
-    &:hover {
-      transform: translateY(-1px);
-    }
   }
 
   .blog-preview {
@@ -436,9 +437,12 @@
     }
   }
 
-  // Section titles not in cards - on dark background
-  h2:not(.consulting h2):not(.about h2):not(.blog-preview h2) {
+  // Section titles that sit on the animated background rather than in a card.
+  // Scoped to `.home`: every page's stylesheet lands in one bundle, and
+  // unscoped this painted the CV's section titles white on their white cards.
+  .home h2:not(.consulting h2):not(.about h2):not(.blog-preview h2) {
     color: white;
+    @include over-background;
   }
 
   .about {
@@ -502,18 +506,18 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
     border: 1px solid var(--border-color);
 
-    &:hover {
+    @include reading-emphasis {
       background: var(--bg-hover);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
       border-color: var(--accent-blue);
+
+      .expertise-icon img {
+        opacity: 1;
+      }
     }
 
     .expertise-icon img {
       opacity: 0.8;
-    }
-
-    &:hover .expertise-icon img {
-      opacity: 1;
     }
 
     // Text inside white cards
@@ -530,7 +534,7 @@
     background: var(--bg-card);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
 
-    &:hover {
+    @include reading-emphasis {
       box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
       border-color: var(--accent-purple);
     }
@@ -544,10 +548,10 @@
       color: var(--text-secondary);
 
       a {
-        color: var(--accent-blue);
+        color: var(--ink-blue);
 
         &:hover {
-          color: var(--accent-pink);
+          color: var(--ink-pink);
           text-shadow: 0 0 8px rgba(233, 30, 99, 0.3);
         }
       }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,3 +1,6 @@
+@import 'variables';
+@import 'mixins';
+
 // CSS Custom Properties for dynamic header height calculation
 :root {
   --header-height: calc(
@@ -199,10 +202,17 @@
   box-shadow: none; // Remove box shadow for transparency
 }
 
-// Header always has blur to match content (light theme)
-// [data-theme='light'] .fixed-header-container.scrolled .header-fixed {
-//   backdrop-filter: blur(3px);
-// }
+// Once anything is scrolled under it, the header stops being a tint over the
+// background and becomes a bar over the page's own cards. Its nav is white in
+// both themes, so without this the links land white-on-white the moment a card
+// passes beneath them. Same scrim in both themes, for the same reason the
+// background stage is.
+.fixed-header-container.scrolled .header-fixed {
+  background: rgba(10, 12, 16, 0.72);
+  backdrop-filter: blur(12px) saturate(140%);
+  -webkit-backdrop-filter: blur(12px) saturate(140%);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.28);
+}
 
 [data-theme='light'] .footer-link {
   background: transparent; // Fully transparent
@@ -293,6 +303,7 @@
   font-size: 1.75rem;
   font-weight: 600;
   color: var(--text-primary);
+  @include over-background;
   font-family:
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
@@ -314,7 +325,7 @@
   }
 
   &:hover {
-    color: var(--accent-color);
+    color: var(--ink-pink);
     transform: translateY(-1px);
 
     &::after {
@@ -327,7 +338,7 @@
   color: white; // White text on dark background
 
   &:hover {
-    color: var(--accent-pink);
+    color: var(--ink-pink);
   }
 }
 
@@ -353,6 +364,7 @@
   width: 2.75rem;
   height: 2.75rem;
   color: var(--text-primary);
+  @include over-background;
   position: relative;
   overflow: hidden;
 
@@ -401,6 +413,7 @@
 .nav-link {
   text-decoration: none;
   color: var(--text-primary);
+  @include over-background;
   font-weight: 500;
   font-size: 1rem;
   white-space: nowrap;
@@ -428,7 +441,7 @@
   }
 
   &:hover {
-    color: var(--accent-color);
+    color: var(--ink-pink);
     background: rgba(231, 76, 60, 0.1);
     transform: translateY(-1px);
 
@@ -442,7 +455,7 @@
   color: white; // White text on dark background
 
   &:hover {
-    color: var(--accent-pink);
+    color: var(--ink-pink);
     background: rgba(233, 30, 99, 0.15);
   }
 }
@@ -558,13 +571,16 @@
 }
 
 // Dark mode icon inversion
+// The icons are black line art inverted to white in both themes, since they
+// sit on the animated background rather than on a page surface. The drop
+// shadow is the icon equivalent of the text halo — without it they vanish into
+// the brighter backgrounds.
 [data-theme='dark'] .footer-link .icon {
-  filter: invert(1);
+  filter: invert(1) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.9));
 }
 
-// Light mode icons - invert for visibility on dark background
 [data-theme='light'] .footer-link .icon {
-  filter: invert(1);
+  filter: invert(1) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.9));
   opacity: 0.9;
 
   &:hover {
@@ -574,6 +590,7 @@
 
 .footer-copyright {
   color: var(--text-muted);
+  @include over-background;
   font-size: 0.8rem;
   margin: 0;
   font-weight: 400;
@@ -584,7 +601,7 @@
 }
 
 [data-theme='light'] .footer-copyright {
-  color: rgba(255, 255, 255, 0.6); // Light text on dark background
+  color: rgba(255, 255, 255, 0.85); // Light text on dark background
 }
 
 @media (max-width: 768px) {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -23,7 +23,7 @@
 @mixin button-primary {
   @include button-base;
   background: var(--accent-color);
-  color: white;
+  color: var(--on-fill);
   border-color: var(--accent-color);
   box-shadow: var(--shadow-sm);
   position: relative;
@@ -91,7 +91,7 @@
   &:hover {
     background: var(--bg-secondary);
     border-color: var(--retro-green);
-    color: var(--retro-green);
+    color: var(--ink-primary);
     transform: translateY(-2px);
     box-shadow:
       0 0 20px rgba(0, 255, 136, 0.3),
@@ -107,6 +107,20 @@
   }
 }
 
+// Text that sits directly on the animated background rather than on a page
+// surface — the nav, the footer, page titles above the cards.
+//
+// The backgrounds do not follow the theme: the same six run in both, from a
+// near-black graph to a saturated yellow PDE field. So this cannot be solved
+// with a colour, and the text carries its own halo instead — a tight, nearly
+// opaque layer that holds an edge against a bright cell, plus a wider soft one
+// that fills the gaps between cells.
+@mixin over-background {
+  text-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.9),
+    0 0 12px rgba(0, 0, 0, 0.6);
+}
+
 @mixin academic-underline {
   position: relative;
 
@@ -120,6 +134,34 @@
     height: 3px;
     background: var(--accent-color);
     border-radius: 2px;
+  }
+}
+
+// The emphasis a card takes on when it is the one being read — either because
+// a pointer is over it or because the scroll position has arrived at it. Both
+// routes get the same treatment so the site has one idea of "this one".
+//
+// Hover is gated on a real pointer: on touch it latches after a tap and leaves
+// a card lit for the rest of the session, on cards that mostly go nowhere.
+@mixin reading-emphasis {
+  &.is-active {
+    @content;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      @content;
+    }
+  }
+}
+
+// Movement reserved for pointer hover. Tying a lift to the scroll position
+// makes a list wobble as you read down it.
+@mixin hover-lift($distance: -2px) {
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      transform: translateY($distance);
+    }
   }
 }
 

--- a/src/styles/mobile-interactivity.scss
+++ b/src/styles/mobile-interactivity.scss
@@ -11,20 +11,17 @@ $mobile-breakpoint: 768px;
 .mobile-interactivity-launcher {
   display: none;
 
+  // Bottom edge and height are shared with the chat launcher in the opposite
+  // corner, so the two read as one row of chrome rather than two loose pills.
   @media (max-width: $mobile-breakpoint) {
     display: block;
     position: fixed;
-    bottom: 1.75rem;
-    left: 1.75rem;
+    bottom: 1rem;
+    left: 1rem;
     z-index: 1000;
     font-family: 'JetBrains Mono', 'Fira Code', monospace;
     animation: slideInFromLeftWithFade 0.4s cubic-bezier(0.16, 1, 0.3, 1)
       forwards;
-  }
-
-  @media (max-width: 480px) {
-    bottom: 1rem;
-    left: 1rem;
   }
 }
 
@@ -32,26 +29,28 @@ $mobile-breakpoint: 768px;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.6rem 1rem;
-  background: rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  min-height: 3rem; // Matches the chat launcher's circle
+  padding: 0 1rem;
+  // Was hardcoded dark glass with white text, which in light mode landed as an
+  // unreadable smudge over the white cards. Same floating surface as the chat
+  // launcher, so it follows the theme the way the rest of the chrome does.
+  background: var(--bg-floating);
+  border: 1px solid var(--border-floating);
   border-radius: var(--radius-lg);
-  color: #fff;
+  color: var(--text-primary);
   font-family: inherit;
   font-size: 0.8rem;
   font-weight: 600;
   text-transform: lowercase;
   letter-spacing: -0.01em;
   cursor: pointer;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--shadow-lg);
   transition: all var(--transition-normal);
   -webkit-tap-highlight-color: transparent;
 
   svg {
     flex-shrink: 0;
-    color: var(--primary-color);
+    color: var(--ink-primary);
   }
 
   &:active {
@@ -66,6 +65,11 @@ $mobile-breakpoint: 768px;
 
 .mobile-explore {
   display: none;
+
+  // Explore mode is a dark scrim over the full-bleed background in both
+  // themes, so its accent stays the bright cut rather than following
+  // --ink-primary down to the light theme's darker green.
+  --explore-accent: #00ff88;
 
   @media (max-width: $mobile-breakpoint) {
     display: block;
@@ -215,7 +219,7 @@ $mobile-breakpoint: 768px;
   -webkit-tap-highlight-color: transparent;
 
   &:active {
-    color: var(--primary-color);
+    color: var(--explore-accent);
     background: rgba(255, 255, 255, 0.08);
   }
 }
@@ -242,7 +246,7 @@ $mobile-breakpoint: 768px;
 
   .mobile-explore-title {
     max-width: 100%;
-    color: var(--primary-color);
+    color: var(--explore-accent);
     font-size: 0.8rem;
     font-weight: 600;
     letter-spacing: -0.01em;

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -1,3 +1,6 @@
+@import 'variables';
+@import 'mixins';
+
 .projects-page {
   max-width: 1100px;
   margin: 0 auto;
@@ -38,6 +41,7 @@
 
   p {
     color: var(--text-secondary);
+    @include over-background;
     font-size: 1.1rem;
     line-height: 1.6;
     font-style: italic;
@@ -51,6 +55,9 @@
   margin-bottom: 3rem;
 }
 
+// On the animated background rather than on a card, like the CV's section
+// titles — white with a halo in both themes. Following --text-primary put it at
+// #212121 in the light theme, invisible against the dark stage behind it.
 .section-title {
   font-size: 1.5rem;
   margin-bottom: 1.5rem;
@@ -62,7 +69,8 @@
     monospace;
   text-transform: lowercase;
   letter-spacing: -0.02em;
-  color: var(--text-primary);
+  color: white;
+  @include over-background;
 }
 
 // Projects Grid
@@ -116,7 +124,7 @@
     }
 
     .project-link-indicator {
-      color: var(--primary-color);
+      color: var(--ink-primary);
 
       svg {
         transform: translate(2px, -2px);
@@ -183,8 +191,8 @@
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 0.25rem 0.5rem;
-  background: linear-gradient(135deg, var(--accent-pink), var(--accent-purple));
-  color: white;
+  background: linear-gradient(135deg, var(--accent-pink), var(--fill-purple));
+  color: var(--on-fill);
   border-radius: var(--radius-sm);
   flex-shrink: 0;
 }
@@ -335,7 +343,7 @@
   gap: 0.75rem;
   padding: 0.875rem 1.5rem;
   background: var(--primary-color);
-  color: white;
+  color: var(--on-fill);
   text-decoration: none;
   border-radius: var(--radius-md);
   font-family:

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -16,6 +16,42 @@
   --text-secondary: #b0b0b0; // Light gray
   --text-muted: #808080; // Medium gray
 
+  // --- Accents as text -----------------------------------------------------
+  // The palette above is tuned for fills, glows and hairlines. Set as words on
+  // a card it has to clear 4.5:1 on its own, which the bright cuts already do
+  // against the near-black surfaces here — so in this theme the inks are the
+  // accents unchanged. The light theme redefines them; nothing that renders an
+  // accent as `color` should reach past these.
+  --ink-primary: #00ff88;
+  --ink-cyan: #00d4ff;
+  --ink-pink: #ff0080;
+  --ink-blue: #0080ff;
+  --ink-purple: #ff00ff;
+  --ink-yellow: #ffaa00;
+
+  // Text on a solid accent fill. Every accent in this palette is a bright
+  // mid-tone in both themes — white on top of one lands between 1.3:1 and
+  // 3.8:1 — so filled buttons and tags take near-black, which clears AA on all
+  // of them. Purple is the exception and is handled where it is used.
+  --on-fill: #0a0a0a;
+
+  // Purple as a fill. Every other accent is bright enough in both themes to
+  // carry --on-fill; the light theme's purple is not, and it is usually paired
+  // with pink in a gradient, so it gets a brighter cut rather than the pair
+  // switching to white text and failing on the pink end instead.
+  --fill-purple: #ff00ff;
+
+  // The constant backing the animated backgrounds composite onto. Deliberately
+  // the same in both themes — see the note on .background-stage.
+  --bg-stage: #07080a;
+
+  // Chrome that floats over the animated backgrounds rather than sitting on a
+  // page surface. Opaque on purpose: the backgrounds run from near-black to
+  // saturated yellow, and any translucency at all picks up the hard edge of
+  // whatever card happens to be passing behind it.
+  --bg-floating: #0e1014;
+  --border-floating: rgba(255, 255, 255, 0.16);
+
   // Backgrounds - Consistent black theme
   --bg-primary: #0a0a0a; // Deep black (main background)
   --bg-secondary: rgba(
@@ -74,7 +110,21 @@
   // Text colors - much darker for crisp readability
   --text-primary: #212121; // Almost black - crisp and clear
   --text-secondary: #616161; // Dark gray - good contrast
-  --text-muted: #9e9e9e; // Medium gray - still readable
+  --text-muted: #6e6e6e; // Medium gray - quiet, still clears AA on a card
+
+  // Accents as text: the same hues taken down until they read as words on a
+  // white card. The fill cuts above only manage 2.2:1 to 3.1:1 there.
+  --ink-primary: #00703a;
+  --ink-cyan: #006c7a;
+  --ink-pink: #c2185b;
+  --ink-blue: #1565c0;
+  --ink-purple: #7b1fa2;
+  --ink-yellow: #8a4b00;
+
+  --fill-purple: #ba68c8;
+
+  --bg-floating: #ffffff;
+  --border-floating: rgba(0, 0, 0, 0.12);
 
   // Backgrounds - subtle but distinct layers
   --bg-primary: #f8f9fa; // Very light gray - not pure white


### PR DESCRIPTION
A visual pass driven by four reports: the mobile backgrounds button not adapting to light mode, homepage cards that highlight on tap but do nothing, CV entries whose only affordance was the caret (with the separator crowding the expanded content), and light-mode contrast generally — the CV download buttons plus "a bunch of places that feel like that", and backgrounds that go light in one theme and stay black in another.

They mostly turned out to be the same problem: chrome that assumed a dark page behind it, or a mouse in front of it.

## Backgrounds render as one set now

The simulations draw into a canvas at 90% opacity, so the page colour behind them is part of the picture — and that colour followed the theme. Against the light theme's near-white base the sparse backgrounds (cellular automaton, graph topology) washed out into pale fields, while the dense ones (PDE solver, spectrogram) barely moved. That is the light-vs-black inconsistency.

They now composite onto one constant near-black stage in both themes, which is what the white chrome layered over them always assumed.

## Light-mode contrast

The accent palette is tuned for fills and hairlines. Rendered as words on a white card it only reaches 2.2:1–3.1:1, and white on top of an accent fill lands between 1.3:1 and 3.8:1 — in **both** themes, not just light. Two token sets settle it:

- `--ink-*` — an accent used as text, darkened in the light theme until it clears AA
- `--on-fill` — text on an accent fill, near-black, which clears AA on every accent in the palette

The CV's download buttons were the visible case; the same fix covers skill tags, category chips, filter buttons, the featured badge and the selection colour.

Two bugs surfaced on the way:

- `index.scss` painted **every** `h2` on the site white in light mode, not just the homepage's — so the CV's section titles rendered white on their own white cards.
- The `glow` keyframes replace the static `text-shadow` outright, so the dark halo written next to every page title never actually rendered. It now rides inside the animation.

A sweep of all six pages in both themes reports no text below 4.5:1. The remaining flags in that sweep are near-black on bright gradient fills, which the checker cannot read through a gradient; each was verified by hand at 5.2–14.8:1.

## Reading position instead of taps

The homepage grid, the blog list and the CV entries highlighted on tap and stayed lit — on cards that mostly go nowhere when clicked. `useScrollSpy` marks whichever item is at the reading line instead, recomputed from geometry so it tracks scrolling in both directions, and clears when the list leaves the viewport. Ties light up together, so a grid highlights a whole row rather than one arbitrary cell.

Pointer hover is gated behind `(hover: hover)` so it stops latching on touch. An opened CV entry takes a stronger version of the same emphasis.

## CV entries

The whole summary was always the toggle — it just did not look like one. It now has a hover state, a left rail that lights with the reading position and goes full accent when open, and a chevron styled as a control.

The rule crowding the expanded content turned out to be the summary's **focus ring**, clipped by the card's `overflow: hidden` into a stray line sitting right on what it had just opened. Global focus moved to `:focus-visible`, and a real inset separator took its place with the buffer it should have had.

## Chrome

- The mobile "backgrounds" pill hardcoded dark glass with white text. It and the chat launcher now share one opaque floating surface and the same baseline.
- The header's `scrolled` state read `window.scrollY`, which is always 0 because the page scrolls inside `.layout` — it never fired. It now scrims when a card passes under the nav, which is what kept the white nav links legible over white cards.
- The three CV download buttons sat at different font sizes: the pdf one is an `<a>` (16px), the others `<button>` (13.3px).

## The audit is in the repo

The sweep that found all of this ships as `scripts/audit-contrast.mjs` (`npm run audit:contrast`), so it does not have to be rebuilt by hand next time. It runs the two checks separately, because they are not the same question:

- **Text on a surface** — measured against whatever is actually painted behind it, walking up for the first genuinely opaque ancestor rather than trusting the token it nominally sits on.
- **Text on the animated background** — unmeasurable by definition, so it looks for a halo and flags anything without one. That check is what caught the CV section titles and the projects section headings.

Elements filled with a CSS gradient are listed as "judge this one" rather than guessed at — `backgroundColor` is transparent on those, so there is no single value to measure and no way to know which stop sits under the text. Thirteen show up today, all near-black on a bright fill, all comfortable. Guessing at them is what made the earlier throwaway version of this report ten false failures.

Exits non-zero when anything fails, so it can gate a branch later if you want it to.

## Verification

- 547 unit tests, 25 e2e tests, type-check, lint, production build — all pass
- Visual pass over 5 pages × 2 themes × desktop and mobile, plus the settings and chat panels and mobile explore mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeewH4ViN9QJjHxZZ6dDuG
