### PR TITLE
Soften the mobile window chrome: veil, chip padding, launcher glass

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -202,6 +202,12 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
   } = React.useMemo(() => resolveHero(shownPath), [shownPath]);
   const shouldCollapse = Boolean(hero) && collapsible;
 
+  // The veil is there for the sticky control rows — the chips on blog,
+  // projects and cv that content scrolls underneath. The home page has no
+  // row, so the band up there was darkening a page nothing floats over: a
+  // slab of shade on the field, protecting a collision that cannot happen.
+  const wantsVeil = pathname.replace(/\/+$/, '') !== '';
+
   const previousPathRef = React.useRef<string | null>(null);
   const snapshotRef = React.useRef<HeroSnapshot | null>(null);
   const releaseHeightRef = React.useRef<(() => void) | null>(null);
@@ -669,8 +675,9 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
             <div className="layout" ref={windowRef}>
               {/* A tapered blur pinned to the window's visible top edge:
                   content dissolves as it scrolls out instead of colliding with
-                  whatever floats up there (the cv's sticky controls). */}
-              <div className="window-veil" aria-hidden="true" />
+                  whatever floats up there (the cv's sticky controls). Skipped
+                  where nothing floats — see `wantsVeil`. */}
+              {wantsVeil && <div className="window-veil" aria-hidden="true" />}
               <main className="main" ref={mainRef}>
                 {children}
               </main>

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -356,14 +356,22 @@
     // The chip row is taller on a phone (the thumb padding in controls.scss),
     // and at 88px the veil's solid zone ran out while the chips were still
     // overhead — full-strength text surfaced directly beneath them. The band
-    // deepens and holds solid past the row, so content dissolves before it
-    // ever reaches the chips.
+    // reaches past the row, so content dissolves before it ever reaches the
+    // chips.
+    //
+    // The tint is the light half of that job. It ran near-opaque, which over a
+    // bright field stopped reading as a veil and started reading as a black
+    // bar laid across the top of the page — a shape with its own edges,
+    // louder than the collision it was hiding. The blur is what actually
+    // destroys the text (18px, and the chips add their own on top); the tint
+    // only has to keep the smear from competing, and it does that at a third
+    // of the weight while letting the field show through.
     @media (max-width: 768px) {
       height: 140px;
       background: linear-gradient(
         to bottom,
-        rgba(7, 8, 10, 0.94) 0%,
-        rgba(7, 8, 10, 0.82) 50%,
+        rgba(7, 8, 10, 0.62) 0%,
+        rgba(7, 8, 10, 0.5) 50%,
         rgba(7, 8, 10, 0) 100%
       );
       mask-image: linear-gradient(

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -211,6 +211,16 @@
     min-width: 0;
   }
 
+  // Stuck, the row's own top padding is the entire gap between the chips and
+  // the window's frame, and 0.4rem leaves them all but touching it — on a
+  // phone, where the row is the first thing under the border and the frame is
+  // a hard bright line, that reads as a printing error rather than as a row
+  // parked at the top. More room above than below sets it off the edge; the
+  // bottom stays where it is, so nothing below the row moves.
+  @media (max-width: 768px) {
+    padding-top: 0.85rem;
+  }
+
   @media (max-width: 480px) {
     gap: var(--space-1);
   }

--- a/src/styles/mobile-interactivity.scss
+++ b/src/styles/mobile-interactivity.scss
@@ -1,6 +1,12 @@
 // Mobile interactivity: the touch entry point into the animated backgrounds.
 // Everything in here is mobile-only — desktop drives the backgrounds from the
 // keyboard and its own control cluster.
+//
+// This one is imported by its component rather than through global.scss, so it
+// is its own compilation unit and has to pull the shared layers in itself —
+// the same two lines layout.scss and shortcuts.scss carry.
+@import 'variables';
+@import 'mixins';
 
 $mobile-breakpoint: 768px;
 
@@ -40,14 +46,15 @@ $mobile-breakpoint: 768px;
   width: 3rem; // Matches the chat launcher's box
   height: 3rem;
   padding: 0;
-  // Same floating surface as the chat launcher rather than its own hardcoded
-  // glass, so the two pieces of mobile chrome stay in step.
-  background: var(--bg-floating);
-  border: 1px solid var(--border-floating);
-  border-radius: var(--radius-lg);
-  color: var(--text-primary);
+  // The same machined housing every floating control on the field wears — the
+  // nav capsule, the chat launcher across the row. It used to reach for
+  // --bg-floating instead, which is a flat opaque near-black: over a dark
+  // field the two corners passed for each other, but over a bright one this
+  // one read as a black tile punched into the page while its twin stayed
+  // glass. One mixin, so they cannot drift again.
+  @include capsule-housing;
+  color: var(--text-secondary); // The chat launcher's ink, for the same reason
   cursor: pointer;
-  box-shadow: var(--shadow-lg);
   transition: all var(--transition-normal);
   -webkit-tap-highlight-color: transparent;
 


### PR DESCRIPTION
Four small fixes to how the top of the content window reads on a phone, all found from one screenshot over the bright PDE field.

## The veil

`.window-veil` is a tapered blur riding the window's top edge, there so content scrolling out dissolves instead of colliding with the sticky control chips. Two problems on mobile:

**It rendered on the home page, which has no chips.** The band was darkening a page nothing floats over — protecting a collision that cannot happen, and dimming the first heading in the window for nothing. It's now gated on the path (`layout.tsx`), so it renders only where something actually floats over the top edge.

**Where it does render, it ran near-opaque** (`0.94` → `0.82`). Over a bright field that stopped reading as a veil and started reading as a black bar laid across the page — a shape with its own edges, louder than the collision it was hiding. The blur is what actually destroys the text under the chips (18px, and the chips add their own on top); the tint only has to keep the smear from competing. It's at a third of the weight now (`0.62` → `0.5`).

## The control chips

Once stuck, the row's own top padding is the entire gap between the chips and the window's frame, and `0.4rem` left them all but touching it. On touch widths that's `0.85rem` — measured, the chip top now sits 15px below the panel edge instead of 6px. Bottom padding is unchanged, so nothing below the row moves.

## The backgrounds launcher

It was reaching for `--bg-floating`, a flat opaque near-black, while the chat launcher across the row wears `capsule-housing` (scrim + backdrop blur). Over a dark field the two passed for each other; over a bright one this one read as a black tile punched into the page while its twin stayed glass. Both are the mixin now, and computed styles for the pair are identical — background, blur, border, radius, ink, shadow, box, offset.

That makes `mobile-interactivity.scss` the first stylesheet outside `global.scss` to need the shared layers, so it imports `variables` and `mixins` itself, the way `layout.scss` and `shortcuts.scss` do.

## Verification

Rendered in Chromium at 390×844 (2× DPR, touch) against the bright PDE background, on home / blog / projects / cv, scrolled so the veil is at full strength. The chips still fully obscure the text passing under them; the launchers match; the band no longer has a visible edge.

`npm run type-check`, eslint, prettier and the full unit suite (579 tests) pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TiEJ3LjJ68nLEeugYGrmjs)_