### PR TITLE
Take the doubled scrim off the control-row chips

### DIFF
--- a/src/styles/controls.scss
+++ b/src/styles/controls.scss
@@ -187,7 +187,7 @@
   // Nothing to clear is not an error, so it recedes rather than greys out
   // hard — but only its ink recedes. Whole-element opacity thinned the
   // frosting with the label, and content scrolling under the chip read
-  // straight through its body; the housing stays solid, the text and
+  // straight through its body; the housing keeps its blur, the text and
   // hairline drop contrast instead.
   &:disabled {
     cursor: not-allowed;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -226,16 +226,21 @@
   }
 }
 
-// A loose floating control with nothing behind it, so it has to hold its own
-// over whatever scrolls underneath — including white headings. The window's
-// scrim token laid down twice (0.38 over 0.38 composites to ~0.62) over a
-// blur well past the window's own, which reads as a frosted chip catching the
-// simulation rather than as a collision with the text below it.
+// A loose floating control on the window's own surface. It carries no scrim of
+// its own: the window underneath it has already laid the site's one scrim down,
+// and a second coat on top of that (0.38 over 0.38, ~0.62, over the window's
+// own 0.38) made the control rows the one piece of chrome on the site darker
+// than everything around them — dark slabs parked on the window, against a nav
+// capsule and a chat pill wearing a single coat of the same token. So the chip
+// is the surface it sits on plus a hairline, and the blur does alone what the
+// second coat was there for: it is well past the window's own, so a heading
+// scrolling under a sticky chip smears into a wash instead of reading through
+// the label, and the chip stays exactly the colour of the window, the capsule
+// and the pill.
 @mixin frosted-chip {
-  background-color: var(--window-scrim);
-  background-image: linear-gradient(var(--window-scrim), var(--window-scrim));
-  backdrop-filter: blur(calc(var(--window-blur) * 2.4));
-  -webkit-backdrop-filter: blur(calc(var(--window-blur) * 2.4)); // Safari ≤17
+  background: transparent;
+  backdrop-filter: blur(calc(var(--window-blur) * 4));
+  -webkit-backdrop-filter: blur(calc(var(--window-blur) * 4)); // Safari ≤17
   border: 1px solid var(--border-floating);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
@@ -249,10 +254,24 @@
   white-space: nowrap;
   cursor: pointer;
   transition: all var(--transition-fast);
+
+  // Without a backdrop filter there is nothing at all between the label and
+  // whatever passes under it, so the old scrim comes back on those engines
+  // alone — a chip a shade darker than its surroundings is worth more there
+  // than a chip you cannot read.
+  @supports not (
+    (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))
+  ) {
+    background: var(--window-scrim);
+  }
 }
 
-// The panel a chip opens. Same doubled scrim as the chip itself, so a menu
-// reads as the chip growing rather than as a different material arriving.
+// The panel a chip opens. The chip is the window's own surface, but a menu is
+// an overlay with a list of words in it, and it hangs over whatever the page
+// happens to be showing — so this is the one that keeps the doubled scrim (the
+// same coat the shortcuts panel takes, and for the same reason). The chip marks
+// itself open with a white wash at the same moment, so the two still read as
+// one object opening rather than as a stray dark box.
 @mixin floating-panel {
   position: absolute;
   top: calc(100% + 0.4rem);


### PR DESCRIPTION
The filter chips on blog, projects and cv read as dark slabs parked on the window, next to a nav capsule and a chat pill made of the same material. Most visible on a phone, where the row sits right under the frame with the field bright behind it.

## What was wrong

`frosted-chip` laid `--window-scrim` down twice — `background-color` plus a gradient image of the same colour, 0.38 over 0.38, ~0.62 — and the chips sit inside `.layout`, which has already painted one coat of that same token. So a chip composited to roughly twice the density of everything around it, against `capsule-housing` (the nav capsule, the chat pill, the backgrounds toolbar) wearing a single coat.

## The change

One mixin, so all three control rows move together:

- The chip carries no scrim of its own — transparent plus its hairline — so its colour is exactly the window's, which is exactly the nav capsule's and the chat pill's.
- Blur goes from 2.4× to 4× `--window-blur`, doing alone what the second coat was there for: a heading scrolling under the sticky row smears into a wash instead of reading through the label.
- A `@supports` fallback keeps the old scrim on engines with no `backdrop-filter`, where slightly dark beats unreadable.
- The menu a chip opens keeps its doubled scrim — it is an overlay with a list of words in it, hanging over whatever the page happens to be showing — and the trigger still takes its white open-state wash, so the pair still reads as one object opening.

The comment on the disabled clear-filters chip in `controls.scss` said "the housing stays solid"; it keeps its blur now, so the wording follows.

## Verification

On a dev server at 390px, `isMobile`:

- Computed style on `.ui-dropdown-trigger` is `rgba(0, 0, 0, 0) / blur(20px)`, against `rgba(7, 8, 10, 0.38)` on both `.layout` and `.nav-menu`.
- Before/after screenshots of the blog row on the same background: the chips stop punching dark holes in the field, labels stay legible, and the open menu still grounds its options.
- `prettier --check` clean on both files; the 24 page unit tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GoMaMUeeQ4TVBQKcDLT3dt)_