### PR TITLE
perf: make the chrome's transitions compositor-friendly

### DIFF
--- a/e2e/performance.spec.ts
+++ b/e2e/performance.spec.ts
@@ -1,0 +1,348 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Performance regression tests.
+ *
+ * Two kinds of test live here, on purpose:
+ *
+ * 1. Structural guards — assertions about *how* the chrome is built (which
+ *    properties transition, when expensive filter surfaces exist, how large
+ *    the background's drawing buffer is). These are deterministic, run in
+ *    every browser project, and fail the moment a regression reintroduces a
+ *    pattern this codebase has already paid to remove: `transition: all`,
+ *    an always-on document-wide custom-property publisher, a backdrop filter
+ *    live during a slide.
+ *
+ * 2. Measured metrics — frame times while scrolling, long tasks across a
+ *    navigation. Absolute numbers on CI hardware (software GL, shared CPU)
+ *    are noisy, so these assert only sanity ceilings an order of magnitude
+ *    above healthy values — a real regression (layout storm, runaway loop)
+ *    still trips them — and attach the raw numbers to the report so runs can
+ *    be compared over time. Chromium-only: the APIs they leans on
+ *    (PerformanceObserver longtask) are Blink-specific.
+ */
+
+// The shell takes a beat to mount: the background is lazy-loaded and the
+// panels restore from localStorage after hydration.
+const settle = async (page: import('@playwright/test').Page, ms = 1200) => {
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(ms);
+};
+
+test.describe('structural performance guards', () => {
+  test('the stage and nav transition an explicit property list, not `all`', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await settle(page);
+
+    const props = await page.evaluate(() => {
+      const read = (selector: string) => {
+        const el = document.querySelector(selector);
+        return el ? getComputedStyle(el).transitionProperty : null;
+      };
+      return {
+        stage: read('.stage'),
+        nav: read('.nav'),
+        navLink: read('.nav-link'),
+      };
+    });
+
+    // `all` on a fixed-position container means every state flip diffs the
+    // full computed style set and arms layout properties for animation.
+    expect(props.stage).not.toBeNull();
+    expect(props.stage).not.toContain('all');
+    expect(props.stage).toContain('left');
+    expect(props.stage).toContain('right');
+    expect(props.nav).not.toContain('all');
+    expect(props.navLink).not.toContain('all');
+  });
+
+  test('--window-top publishes only while a sidebar exists to read it', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await settle(page);
+
+    const readTop = () =>
+      page.evaluate(() =>
+        document.documentElement.style.getPropertyValue('--window-top')
+      );
+
+    // Closed panels: no publisher. Every write to a root-level custom
+    // property invalidates style document-wide, so at rest there must be
+    // none — scrolling moves the window's top edge on every frame.
+    expect(await readTop()).toBe('');
+
+    // The keyboard shortcut, not the pill: the launcher wears an entry
+    // animation, and a clicked element that never goes still fails
+    // Playwright's stability wait.
+    await page.keyboard.press('c');
+    await expect
+      .poll(readTop, {
+        message: 'opening the chat should start the publisher',
+      })
+      .toMatch(/px$/);
+  });
+
+  test('the window veil keeps no live blur surface at rest', async ({
+    page,
+  }) => {
+    // The veil only renders off the home route.
+    await page.goto('/blog');
+    await settle(page);
+
+    const veilState = () =>
+      page.evaluate(() => {
+        const layout = document.querySelector('.layout');
+        const veil = document.querySelector('.window-veil');
+        if (!layout || !veil) return null;
+        return {
+          live: layout.classList.contains('veil-live'),
+          visibility: getComputedStyle(veil, '::before').visibility,
+        };
+      });
+
+    // At the top of the page the veil is invisible — and must be *gone*
+    // (visibility), not merely transparent, or its 18px backdrop blur keeps
+    // re-resolving over the animated canvas behind the window every frame.
+    const atRest = await veilState();
+    expect(atRest).not.toBeNull();
+    expect(atRest!.live).toBe(false);
+    expect(atRest!.visibility).toBe('hidden');
+
+    // Scrolled, the veil comes back for exactly as long as there is
+    // something to veil. The publisher runs on the page's animation frames,
+    // which crawl under parallel software-GL load — hence the long timeout.
+    await page.evaluate(() => {
+      const layout = document.querySelector('.layout');
+      if (layout) layout.scrollTop = 200;
+    });
+    await expect
+      .poll(async () => (await veilState())!.visibility, {
+        message: 'scrolling should re-arm the veil',
+        timeout: 20_000,
+      })
+      .toBe('visible');
+  });
+
+  test('the mobile chat sheet sheds its backdrop filter while sliding', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!isMobile, 'the full-screen sheet only exists on phone widths');
+
+    await page.goto('/');
+    await settle(page);
+    // Keyboard rather than the pill — see the note in the publisher test.
+    await page.keyboard.press('c');
+    const sheet = page.locator('.chat-sidebar');
+    await expect(sheet).toBeVisible();
+
+    const readFilter = () =>
+      sheet.evaluate(el => {
+        const cs = getComputedStyle(el) as CSSStyleDeclaration & {
+          webkitBackdropFilter?: string;
+        };
+        return cs.backdropFilter || cs.webkitBackdropFilter || '';
+      });
+
+    // Parked, the sheet wears the window's frosted glass — poll for the
+    // *settled* value, not the first interpolated frame of the settle fade.
+    // The timeout is generous because the fade advances with the page's
+    // animation clock, and under parallel software-GL load a 220ms fade can
+    // take seconds of wall time to paint its final frame.
+    await expect.poll(readFilter, { timeout: 20_000 }).toBe('blur(5px)');
+
+    // The moving states take the filter off: a full-screen backdrop filter
+    // re-resolved on every frame of a 300ms slide is the most expensive
+    // thing a phone GPU can be asked to do while also compositing the move.
+    // Asserted against the stylesheet rather than by toggling classes on the
+    // live element — React owns className and resets hand-added classes on
+    // any re-render.
+    const gatingRules = await page.evaluate(() => {
+      const found: Record<string, string> = {};
+      const walk = (rules: CSSRuleList) => {
+        for (const rule of Array.from(rules)) {
+          if (rule instanceof CSSMediaRule || rule instanceof CSSSupportsRule) {
+            walk(rule.cssRules);
+          } else if (
+            rule instanceof CSSStyleRule &&
+            /\.(chat-sidebar|settings-sidebar)\.(opening|closing)/.test(
+              rule.selectorText
+            )
+          ) {
+            const value = rule.style.getPropertyValue('backdrop-filter');
+            if (value) found[rule.selectorText] = value;
+          }
+        }
+      };
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          walk(sheet.cssRules);
+        } catch {
+          // Cross-origin sheet — none of ours.
+        }
+      }
+      return found;
+    });
+
+    const gated = (fragment: string) =>
+      Object.entries(gatingRules).some(
+        ([selector, value]) =>
+          selector.includes(fragment) && value.trim() === 'none'
+      );
+    expect(gated('.chat-sidebar.opening')).toBe(true);
+    expect(gated('.chat-sidebar.closing')).toBe(true);
+    expect(gated('.settings-sidebar.closing')).toBe(true);
+  });
+
+  test('the background renders at the capped mobile pixel ratio', async ({
+    page,
+    isMobile,
+    browserName,
+  }) => {
+    test.skip(!isMobile, 'the 1.5 cap only applies at phone widths');
+    test.skip(
+      browserName !== 'chromium',
+      'headless WebGL is only dependable in chromium'
+    );
+
+    // Pin the cheapest background so the test never depends on the random
+    // pick, then wait for its canvas.
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'animatedBackgroundSettings',
+        JSON.stringify({ currentBackgroundId: 'simple-waves' })
+      );
+    });
+    await page.goto('/');
+    await settle(page, 2500);
+
+    const sizes = await page.evaluate(() => {
+      const canvas = document.querySelector('canvas');
+      if (!canvas) return null;
+      return {
+        buffer: canvas.width,
+        css: window.innerWidth,
+        dpr: window.devicePixelRatio,
+      };
+    });
+    test.skip(sizes === null, 'no WebGL canvas mounted in this environment');
+
+    // On a >1.5x phone the drawing buffer must be 1.5 × CSS pixels — the
+    // uncapped device ratio would roughly double the per-frame fill cost of
+    // a canvas that is then composited under a scrim anyway.
+    const expected = sizes!.css * Math.min(sizes!.dpr, 1.5);
+    expect(Math.abs(sizes!.buffer - expected)).toBeLessThanOrEqual(2);
+  });
+});
+
+test.describe('measured metrics (chromium)', () => {
+  test('scrolling the window stays under the frame-time ceiling', async ({
+    page,
+    browserName,
+    isMobile,
+  }, testInfo) => {
+    test.skip(browserName !== 'chromium', 'frame sampling tuned for Blink');
+    test.skip(isMobile, 'desktop project only — one stable baseline');
+    // Software GL on CI hardware runs frames an order of magnitude slower
+    // than any real device; give the sampler room to finish regardless.
+    test.setTimeout(90_000);
+
+    await page.goto('/cv'); // the longest page — worst-case layout
+    await settle(page, 2000);
+
+    const metrics = await page.evaluate(
+      () =>
+        new Promise<{ frames: number; avg: number; p95: number; max: number }>(
+          resolve => {
+            const layout = document.querySelector('.layout') as HTMLElement;
+            const deltas: number[] = [];
+            let last = performance.now();
+            let scrolled = 0;
+            const step = (now: number) => {
+              deltas.push(now - last);
+              last = now;
+              // ~30px/frame emulates a brisk flick through the hero collapse
+              // range and on into the document; 60 samples is enough for a
+              // stable p95 without stretching the test on slow CI frames.
+              scrolled += 30;
+              layout.scrollTop = scrolled;
+              if (scrolled < 1800) {
+                requestAnimationFrame(step);
+              } else {
+                deltas.sort((a, b) => a - b);
+                const avg = deltas.reduce((s, d) => s + d, 0) / deltas.length;
+                resolve({
+                  frames: deltas.length,
+                  avg,
+                  p95: deltas[Math.floor(deltas.length * 0.95)],
+                  max: deltas[deltas.length - 1],
+                });
+              }
+            };
+            requestAnimationFrame(step);
+          }
+        )
+    );
+
+    await testInfo.attach('scroll-frame-times', {
+      body: JSON.stringify(metrics, null, 2),
+      contentType: 'application/json',
+    });
+
+    // Sanity ceilings, not targets: with software GL on shared CPUs and the
+    // suite running fully parallel, healthy frames average in the hundreds
+    // of milliseconds (~180ms exclusive, ~800ms under full parallel load —
+    // the WebGL background alone costs that under swiftshader). The
+    // ceilings only catch catastrophic regressions; the attached numbers
+    // are the real measurement, compare them across runs.
+    expect(metrics.avg).toBeLessThan(1500);
+    expect(metrics.p95).toBeLessThan(5000);
+  });
+
+  test('a page navigation stays under the long-task ceiling', async ({
+    page,
+    browserName,
+    isMobile,
+  }, testInfo) => {
+    test.skip(browserName !== 'chromium', 'longtask observer is Blink-only');
+    test.skip(isMobile, 'desktop project only — one stable baseline');
+
+    await page.goto('/');
+    await settle(page, 2000);
+
+    // Arm the observer, run the shell's whole navigation transition (hero
+    // swap, height ease, content rise), then read the tally.
+    await page.evaluate(() => {
+      const w = window as typeof window & { __longTasks?: number[] };
+      w.__longTasks = [];
+      new PerformanceObserver(list => {
+        for (const entry of list.getEntries()) {
+          w.__longTasks!.push(entry.duration);
+        }
+      }).observe({ type: 'longtask', buffered: false });
+    });
+
+    await page.getByRole('navigation').getByText('blog').click();
+    await page.waitForURL(/\/blog/);
+    await page.waitForTimeout(1500); // every timeline in the transition ends
+
+    const longTasks = await page.evaluate(
+      () => (window as typeof window & { __longTasks?: number[] }).__longTasks!
+    );
+    const total = longTasks.reduce((s, d) => s + d, 0);
+
+    await testInfo.attach('navigation-long-tasks', {
+      body: JSON.stringify({ count: longTasks.length, total, longTasks }),
+      contentType: 'application/json',
+    });
+
+    // Same philosophy as above: a generous ceiling that real regressions
+    // (a transition re-armed on layout properties, a rebuild storm) exceed.
+    // ~4s totals are normal for CI-grade hardware running software GL; the
+    // attached numbers are the measurement to compare across runs.
+    expect(total).toBeLessThan(10_000);
+  });
+});

--- a/src/__tests__/unit/components/BackgroundProvider.persist.test.tsx
+++ b/src/__tests__/unit/components/BackgroundProvider.persist.test.tsx
@@ -1,0 +1,171 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import {
+  BackgroundProvider,
+  useBackground,
+} from '../../../components/BackgroundProvider';
+import { SettingsPanelProvider } from '../../../components/SettingsPanelContext';
+
+jest.mock('../../../components/animated-backgrounds/index', () => {
+  const Dummy = () => null;
+  const registry = [
+    {
+      id: 'one',
+      name: 'One',
+      description: 'First',
+      component: Dummy,
+      defaultSettings: { opacity: 0.8 },
+      settingsSchema: [],
+    },
+  ];
+  return {
+    backgroundRegistry: registry,
+    getBackgroundById: (id: string) => registry.find(bg => bg.id === id),
+  };
+});
+
+const STORAGE_KEY = 'animatedBackgroundSettings';
+
+const Probe: React.FC = () => {
+  const { updateCurrentSettings } = useBackground();
+  return (
+    <button onClick={() => updateCurrentSettings({ opacity: 0.1 } as never)}>
+      edit
+    </button>
+  );
+};
+
+const renderProbe = () =>
+  render(
+    <SettingsPanelProvider>
+      <BackgroundProvider initialBackgroundId="one">
+        <Probe />
+      </BackgroundProvider>
+    </SettingsPanelProvider>
+  );
+
+// The shared setup stubs localStorage with inert jest.fn()s, which is fine for
+// suites that only care that it was called. These assert on what survives, so
+// they need a store that actually stores.
+const installStore = () => {
+  const store = new Map<string, string>();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, String(value)),
+      removeItem: (key: string) => store.delete(key),
+      clear: () => store.clear(),
+      key: (i: number) => Array.from(store.keys())[i] ?? null,
+      get length() {
+        return store.size;
+      },
+    },
+  });
+};
+
+const savedOpacity = () => {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw ? JSON.parse(raw).settings?.one?.opacity : undefined;
+};
+
+// The write is debounced so that dragging a slider doesn't stringify the whole
+// settings blob once per input event. That buys a window in which a change
+// exists only in memory, and these cover the ways out of it.
+describe('settings persistence', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    installStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('debounces the write rather than saving on every change', () => {
+    renderProbe();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      screen.getByText('edit').click();
+    });
+    // Still in the debounce window: nothing written yet.
+    expect(savedOpacity()).not.toBe(0.1);
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+    expect(savedOpacity()).toBe(0.1);
+  });
+
+  it('flushes a pending write when the page is hidden', () => {
+    renderProbe();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      screen.getByText('edit').click();
+    });
+    expect(savedOpacity()).not.toBe(0.1);
+
+    // A backgrounded tab can be discarded without ever running the timer, so
+    // the change has to reach storage on the way out.
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+    expect(savedOpacity()).toBe(0.1);
+  });
+
+  it('flushes a pending write when the provider unmounts', () => {
+    const { unmount } = renderProbe();
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    act(() => {
+      screen.getByText('edit').click();
+    });
+    expect(savedOpacity()).not.toBe(0.1);
+
+    act(() => {
+      unmount();
+    });
+    expect(savedOpacity()).toBe(0.1);
+  });
+
+  it('flushes the restored settings, never the first-render defaults', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        currentBackgroundId: 'one',
+        settings: { one: { opacity: 0.42 } },
+      })
+    );
+
+    // No initialBackgroundId, so the restore path runs. The flush paths hang
+    // off the same `mounted` guard as the debounced write, so a page hidden
+    // immediately after load writes back what was restored — it can never
+    // clobber a saved setting with the deterministic defaults the provider
+    // renders before hydration.
+    const { unmount } = render(
+      <SettingsPanelProvider>
+        <BackgroundProvider>
+          <Probe />
+        </BackgroundProvider>
+      </SettingsPanelProvider>
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event('pagehide'));
+    });
+    expect(savedOpacity()).toBe(0.42);
+
+    act(() => {
+      unmount();
+    });
+    expect(savedOpacity()).toBe(0.42);
+  });
+});

--- a/src/__tests__/unit/components/animated-backgrounds/core/usePrefersReducedMotion.test.tsx
+++ b/src/__tests__/unit/components/animated-backgrounds/core/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,64 @@
+import { act, render, screen } from '@testing-library/react';
+import React from 'react';
+import { usePrefersReducedMotion } from '../../../../../components/animated-backgrounds/core/usePrefersReducedMotion';
+
+// A controllable stand-in for the shared setup's inert matchMedia stub, so a
+// test can flip the preference the way an OS settings toggle would.
+const installMedia = (initial: boolean) => {
+  const listeners = new Set<() => void>();
+  const media = {
+    matches: initial,
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn((_: string, fn: () => void) => listeners.add(fn)),
+    removeEventListener: jest.fn((_: string, fn: () => void) =>
+      listeners.delete(fn)
+    ),
+    dispatchEvent: jest.fn(),
+  };
+  (window.matchMedia as unknown as jest.Mock).mockImplementation(() => media);
+  return {
+    media,
+    listeners,
+    set(value: boolean) {
+      media.matches = value;
+      listeners.forEach(fn => fn());
+    },
+  };
+};
+
+const Probe: React.FC = () => (
+  <span data-testid="reduced">{String(usePrefersReducedMotion())}</span>
+);
+
+describe('usePrefersReducedMotion', () => {
+  it('settles on the current preference after mount', () => {
+    installMedia(true);
+    render(<Probe />);
+    expect(screen.getByTestId('reduced')).toHaveTextContent('true');
+  });
+
+  it('follows the preference when it is toggled mid-session', () => {
+    const control = installMedia(false);
+    render(<Probe />);
+    expect(screen.getByTestId('reduced')).toHaveTextContent('false');
+
+    // The whole point of the hook over a one-shot `.matches` read: a value
+    // latched into a long-lived effect would never see this.
+    act(() => control.set(true));
+    expect(screen.getByTestId('reduced')).toHaveTextContent('true');
+
+    act(() => control.set(false));
+    expect(screen.getByTestId('reduced')).toHaveTextContent('false');
+  });
+
+  it('unsubscribes on unmount', () => {
+    const control = installMedia(false);
+    const { unmount } = render(<Probe />);
+    expect(control.listeners.size).toBe(1);
+    unmount();
+    expect(control.listeners.size).toBe(0);
+  });
+});

--- a/src/components/BackgroundProvider.tsx
+++ b/src/components/BackgroundProvider.tsx
@@ -174,9 +174,16 @@ export const BackgroundProvider: React.FC<BackgroundProviderProps> = ({
   // Persist settings to localStorage. Guarded by `mounted` so the deterministic
   // default state written during the first render can't clobber a user's
   // persisted settings before the restore effect above has run.
+  //
+  // Debounced: this used to stringify the whole settings blob synchronously on
+  // every state change, which meant once per input event while a slider was
+  // being dragged — main-thread work billed to the exact frames the user was
+  // watching the background respond in. The write only has to happen once the
+  // dust settles.
   useEffect(() => {
     if (!mounted) return;
-    if (typeof window !== 'undefined') {
+    if (typeof window === 'undefined') return;
+    const timer = window.setTimeout(() => {
       try {
         localStorage.setItem(
           'animatedBackgroundSettings',
@@ -188,7 +195,8 @@ export const BackgroundProvider: React.FC<BackgroundProviderProps> = ({
           error
         );
       }
-    }
+    }, 400);
+    return () => window.clearTimeout(timer);
   }, [state, mounted]);
 
   // Computed values
@@ -312,23 +320,43 @@ export const BackgroundProvider: React.FC<BackgroundProviderProps> = ({
     }
   }, [isSettingsPanelOpen, setSettingsPanelOpen, setClosingSettingsPanel]);
 
-  const contextValue: BackgroundContextType = {
-    state,
-    switchToNextBackground,
-    switchToPreviousBackground,
-    selectBackground,
-    updateCurrentSettings,
-    resetCurrentSettings,
-    toggleSettingsPanel,
-    closeSettingsPanel,
-    audioControls,
-    setAudioControls,
-    overlayOpacity,
-    setOverlayOpacity,
-    currentBackground,
-    currentSettings,
-    mounted,
-  };
+  // Memoized so a provider render doesn't hand every consumer a fresh object
+  // — the callbacks above are all stable, so this only changes when one of the
+  // actual values does.
+  const contextValue: BackgroundContextType = useMemo(
+    () => ({
+      state,
+      switchToNextBackground,
+      switchToPreviousBackground,
+      selectBackground,
+      updateCurrentSettings,
+      resetCurrentSettings,
+      toggleSettingsPanel,
+      closeSettingsPanel,
+      audioControls,
+      setAudioControls,
+      overlayOpacity,
+      setOverlayOpacity,
+      currentBackground,
+      currentSettings,
+      mounted,
+    }),
+    [
+      state,
+      switchToNextBackground,
+      switchToPreviousBackground,
+      selectBackground,
+      updateCurrentSettings,
+      resetCurrentSettings,
+      toggleSettingsPanel,
+      closeSettingsPanel,
+      audioControls,
+      overlayOpacity,
+      currentBackground,
+      currentSettings,
+      mounted,
+    ]
+  );
 
   return (
     <BackgroundContext.Provider value={contextValue}>

--- a/src/components/BackgroundProvider.tsx
+++ b/src/components/BackgroundProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -180,24 +181,57 @@ export const BackgroundProvider: React.FC<BackgroundProviderProps> = ({
   // being dragged — main-thread work billed to the exact frames the user was
   // watching the background respond in. The write only has to happen once the
   // dust settles.
+  const persistSettings = useCallback((value: BackgroundManagerState) => {
+    try {
+      localStorage.setItem('animatedBackgroundSettings', JSON.stringify(value));
+    } catch (error) {
+      console.warn(
+        'Failed to save background settings to localStorage:',
+        error
+      );
+    }
+  }, []);
+
+  // The state a debounced write still owes to storage, or null when storage is
+  // already up to date. Only ever set past `mounted`, so the flush paths below
+  // can never write the pre-restore defaults over a real saved setting.
+  const pendingWriteRef = useRef<BackgroundManagerState | null>(null);
+
   useEffect(() => {
     if (!mounted) return;
     if (typeof window === 'undefined') return;
+    pendingWriteRef.current = state;
     const timer = window.setTimeout(() => {
-      try {
-        localStorage.setItem(
-          'animatedBackgroundSettings',
-          JSON.stringify(state)
-        );
-      } catch (error) {
-        console.warn(
-          'Failed to save background settings to localStorage:',
-          error
-        );
-      }
+      persistSettings(state);
+      pendingWriteRef.current = null;
     }, 400);
     return () => window.clearTimeout(timer);
-  }, [state, mounted]);
+  }, [state, mounted, persistSettings]);
+
+  // The debounce buys smooth frames at the cost of a 400ms window where a
+  // change exists only in memory, so every way out of that window flushes it.
+  // `pagehide` and the hidden `visibilitychange` are the pair that actually
+  // fire on mobile, where a backgrounded tab can be discarded outright without
+  // ever seeing `unload`; the cleanup covers a provider torn down in place.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const flush = () => {
+      const pending = pendingWriteRef.current;
+      if (pending === null) return;
+      pendingWriteRef.current = null;
+      persistSettings(pending);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+    window.addEventListener('pagehide', flush);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      flush();
+    };
+  }, [persistSettings]);
 
   // Computed values
   const currentBackground = useMemo(() => {

--- a/src/components/SettingsPanelContext.tsx
+++ b/src/components/SettingsPanelContext.tsx
@@ -1,8 +1,10 @@
 import React, {
   createContext,
   ReactNode,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react';
 
@@ -50,7 +52,10 @@ export const SettingsPanelProvider: React.FC<SettingsPanelProviderProps> = ({
     const restore = (key: string, apply: (open: boolean) => void) => {
       try {
         const saved = localStorage.getItem(key);
-        if (saved !== null) apply(saved === 'true');
+        // Loose on purpose: a spec-compliant store answers null for a missing
+        // key, but stubbed stores (tests, privacy shims) answer undefined,
+        // and either one means "nothing saved" — not "saved: closed".
+        if (saved != null) apply(saved === 'true');
       } catch (error) {
         console.warn(`Failed to load ${key} from localStorage:`, error);
       }
@@ -91,41 +96,59 @@ export const SettingsPanelProvider: React.FC<SettingsPanelProviderProps> = ({
     }
   }, [isChatPanelOpen, hydrated]);
 
-  const setSettingsPanelOpen = (isOpen: boolean) => {
+  // Stable setter identities and a memoized value: half the site consumes
+  // this context (the shell, both panels, the background manager), and every
+  // panel toggle re-renders them all — handing out fresh setter functions on
+  // top of that defeated every downstream memo and effect dep list.
+  const setSettingsPanelOpen = useCallback((isOpen: boolean) => {
     setIsSettingsPanelOpen(isOpen);
-  };
+  }, []);
 
-  const setClosingSettingsPanel = (isClosing: boolean) => {
+  const setClosingSettingsPanel = useCallback((isClosing: boolean) => {
     setIsClosingSettingsPanel(isClosing);
-  };
+  }, []);
 
-  const setChatPanelOpen = (isOpen: boolean) => {
+  const setChatPanelOpen = useCallback((isOpen: boolean) => {
     setIsChatPanelOpen(isOpen);
-  };
+  }, []);
 
-  const setClosingChatPanel = (isClosing: boolean) => {
+  const setClosingChatPanel = useCallback((isClosing: boolean) => {
     setIsClosingChatPanel(isClosing);
-  };
+  }, []);
 
-  const setContentHidden = (isHidden: boolean) => {
+  const setContentHidden = useCallback((isHidden: boolean) => {
     setIsContentHidden(isHidden);
-  };
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      isSettingsPanelOpen,
+      isClosingSettingsPanel,
+      isChatPanelOpen,
+      isClosingChatPanel,
+      isContentHidden,
+      setSettingsPanelOpen,
+      setClosingSettingsPanel,
+      setChatPanelOpen,
+      setClosingChatPanel,
+      setContentHidden,
+    }),
+    [
+      isSettingsPanelOpen,
+      isClosingSettingsPanel,
+      isChatPanelOpen,
+      isClosingChatPanel,
+      isContentHidden,
+      setSettingsPanelOpen,
+      setClosingSettingsPanel,
+      setChatPanelOpen,
+      setClosingChatPanel,
+      setContentHidden,
+    ]
+  );
 
   return (
-    <SettingsPanelContext.Provider
-      value={{
-        isSettingsPanelOpen,
-        isClosingSettingsPanel,
-        isChatPanelOpen,
-        isClosingChatPanel,
-        isContentHidden,
-        setSettingsPanelOpen,
-        setClosingSettingsPanel,
-        setChatPanelOpen,
-        setClosingChatPanel,
-        setContentHidden,
-      }}
-    >
+    <SettingsPanelContext.Provider value={value}>
       {children}
     </SettingsPanelContext.Provider>
   );

--- a/src/components/animated-backgrounds/BackgroundManager.tsx
+++ b/src/components/animated-backgrounds/BackgroundManager.tsx
@@ -134,11 +134,20 @@ const BackgroundManager: React.FC<BackgroundManagerProps> = ({ className }) => {
 
   // Background cycling effect
   useEffect(() => {
+    // Someone who asked the OS for less motion should not get a fullscreen
+    // fade-to-black and a fresh WebGL scene every twelve seconds. The current
+    // background still runs; it just stays.
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     // Disable cycling when panel is open or closing
     if (
       state.showSettingsPanel ||
       state.closingSettingsPanel ||
       cyclePaused ||
+      prefersReducedMotion ||
       !cycleEnabled
     ) {
       clearTimers();

--- a/src/components/animated-backgrounds/BackgroundManager.tsx
+++ b/src/components/animated-backgrounds/BackgroundManager.tsx
@@ -5,6 +5,7 @@ import { useSettingsPanel } from '../SettingsPanelContext';
 import BackgroundControls from './BackgroundControls';
 import MobileInteractivity from './MobileInteractivity';
 import { useIsMobileViewport } from './core/useIsMobileViewport';
+import { usePrefersReducedMotion } from './core/usePrefersReducedMotion';
 
 interface BackgroundManagerProps {
   className?: string;
@@ -112,6 +113,14 @@ const BackgroundManager: React.FC<BackgroundManagerProps> = ({ className }) => {
   const fadeDurationMs = siteConfig.animatedBackgrounds?.fadeDurationMs ?? 1200;
   const cycleEnabled = siteConfig.animatedBackgrounds?.cycleEnabled ?? true;
 
+  // Someone who asked the OS for less motion should not get a fullscreen
+  // fade-to-black and a fresh WebGL scene every twelve seconds. The current
+  // background still runs; it just stays. Read through the hook rather than
+  // sampled inside the cycling effect, so that toggling the preference
+  // mid-session starts or stops the cycle instead of waiting for some
+  // unrelated dependency to change.
+  const prefersReducedMotion = usePrefersReducedMotion();
+
   const fadeInTimeoutRef = useRef<number | null>(null);
   const playTimeoutRef = useRef<number | null>(null);
   const fadeOutTimeoutRef = useRef<number | null>(null);
@@ -134,14 +143,6 @@ const BackgroundManager: React.FC<BackgroundManagerProps> = ({ className }) => {
 
   // Background cycling effect
   useEffect(() => {
-    // Someone who asked the OS for less motion should not get a fullscreen
-    // fade-to-black and a fresh WebGL scene every twelve seconds. The current
-    // background still runs; it just stays.
-    const prefersReducedMotion =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
     // Disable cycling when panel is open or closing
     if (
       state.showSettingsPanel ||
@@ -206,6 +207,7 @@ const BackgroundManager: React.FC<BackgroundManagerProps> = ({ className }) => {
     state.showSettingsPanel,
     state.closingSettingsPanel,
     cyclePaused,
+    prefersReducedMotion,
   ]);
 
   // When the settings panel fully closes, resume cycle from visible phase

--- a/src/components/animated-backgrounds/MobileInteractivity.tsx
+++ b/src/components/animated-backgrounds/MobileInteractivity.tsx
@@ -68,6 +68,20 @@ const MobileInteractivity: React.FC = () => {
     }
   }, [isMobile, isContentHidden, setContentHidden]);
 
+  // On this width the settings sheet belongs to explore mode — the sheet
+  // claims the lower half of the screen so the background above it can be
+  // watched, not the page. But the open flag persists in localStorage and
+  // explore mode does not, so a sheet left open on a desktop can restore on
+  // a phone with the page content still mounted behind it, dimmed by the
+  // stage's generic panel fallback instead of hidden. Arriving in that state
+  // adopts it into explore, exactly as if the sheet had been opened here.
+  useEffect(() => {
+    if (isMobile && settingsOpen && !isContentHidden) {
+      enteredHereRef.current = true;
+      setContentHidden(true);
+    }
+  }, [isMobile, settingsOpen, isContentHidden, setContentHidden]);
+
   // The "tap to hide" nudge is only useful the first moment of a session in
   // explore mode; retire it so the chrome settles into just the controls.
   useEffect(() => {

--- a/src/components/animated-backgrounds/backgrounds/cellular-automaton/CellularAutomatonBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/cellular-automaton/CellularAutomatonBackground.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { makeRuleTables, population, stepLife } from './automaton';
 import { CellularAutomatonSettings } from './config';
@@ -48,7 +49,7 @@ const CellularAutomatonBackground: React.FC<
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     const renderer = new THREE.WebGLRenderer({ alpha: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
     container.appendChild(renderer.domElement);
 
     const tables = makeRuleTables(rule);
@@ -359,7 +360,7 @@ const CellularAutomatonBackground: React.FC<
     const applyResize = () => {
       resizeFrame = null;
       renderer.setSize(window.innerWidth, window.innerHeight);
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      renderer.setPixelRatio(getRenderPixelRatio());
 
       // Most of those resizes are a few pixels of browser chrome and leave the
       // grid the same shape, in which case there is nothing to rebuild at all.

--- a/src/components/animated-backgrounds/backgrounds/graph-topology/GraphTopologyBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/graph-topology/GraphTopologyBackground.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { GraphTopologySettings } from './config';
 
@@ -204,7 +205,7 @@ const GraphTopologyBackground: React.FC<
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
     container.appendChild(renderer.domElement);
 
     // Animation Speed is a master multiplier over this background's own rates:
@@ -851,16 +852,27 @@ const GraphTopologyBackground: React.FC<
 
     animationRef.current = requestAnimationFrame(renderFrame);
 
-    const handleResize = () => {
+    // Applied at most once per frame — a phone's URL bar fires resize
+    // repeatedly over a single flick, and each raw call reallocates the
+    // drawing buffer mid-scroll.
+    let resizeFrame: number | null = null;
+    const applyResize = () => {
+      resizeFrame = null;
       renderer.setSize(window.innerWidth, window.innerHeight);
       // Line2 widths are screen-space, so the materials need the viewport size.
       lineResolution.set(window.innerWidth, window.innerHeight);
+    };
+    const handleResize = () => {
+      if (resizeFrame === null) {
+        resizeFrame = requestAnimationFrame(applyResize);
+      }
     };
     window.addEventListener('resize', handleResize);
 
     return () => {
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
       window.removeEventListener('resize', handleResize);
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
       // Cleanup
       edgeSegments.forEach(l => {
         l.geometry?.dispose?.();

--- a/src/components/animated-backgrounds/backgrounds/pde-solver/PDESolverBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/pde-solver/PDESolverBackground.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { PDESolverSettings } from './config';
 import { createInitialState, stepPDESolver, index } from './pde-solver';
@@ -92,7 +93,7 @@ const PDESolverBackground: React.FC<
 
     const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
     renderer.setClearColor(0x000000, 0);
     container.appendChild(renderer.domElement);
     rendererRef.current = renderer;
@@ -166,8 +167,12 @@ const PDESolverBackground: React.FC<
 
     animate();
 
-    // Handle window resize
-    const handleResize = () => {
+    // Handle window resize, at most once per frame — a phone's URL bar fires
+    // resize repeatedly over a single flick, and each raw call reallocates the
+    // drawing buffer mid-scroll.
+    let resizeFrame: number | null = null;
+    const applyResize = () => {
+      resizeFrame = null;
       if (cameraRef.current && rendererRef.current) {
         const { innerWidth, innerHeight } = window;
         cameraRef.current.aspect = innerWidth / innerHeight;
@@ -176,12 +181,20 @@ const PDESolverBackground: React.FC<
         rendererRef.current.setSize(innerWidth, innerHeight);
       }
     };
+    const handleResize = () => {
+      if (resizeFrame === null) {
+        resizeFrame = requestAnimationFrame(applyResize);
+      }
+    };
 
     window.addEventListener('resize', handleResize);
 
     // Cleanup
     return () => {
       window.removeEventListener('resize', handleResize);
+      if (resizeFrame !== null) {
+        cancelAnimationFrame(resizeFrame);
+      }
 
       if (animationFrameRef.current !== null) {
         cancelAnimationFrame(animationFrameRef.current);

--- a/src/components/animated-backgrounds/backgrounds/shortest-path-lab/ShortestPathLabBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/shortest-path-lab/ShortestPathLabBackground.tsx
@@ -6,6 +6,7 @@ import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPa
 import { Line2 } from 'three/examples/jsm/lines/Line2.js';
 import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
 import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { ShortestPathLabSettings } from './config';
 
@@ -97,7 +98,7 @@ const ShortestPathLabBackground: React.FC<
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
     container.appendChild(renderer.domElement);
 
     // Optional bloom composer
@@ -553,7 +554,12 @@ const ShortestPathLabBackground: React.FC<
 
     animationRef.current = requestAnimationFrame(render);
 
-    const handleResize = () => {
+    // Applied at most once per frame — a phone's URL bar fires resize
+    // repeatedly over a single flick, and each raw call reallocates the
+    // drawing buffer (and the bloom pass's render targets) mid-scroll.
+    let resizeFrame: number | null = null;
+    const applyResize = () => {
+      resizeFrame = null;
       renderer.setSize(window.innerWidth, window.innerHeight);
       // Line2 widths are in screen space, so the materials need to know how
       // big the screen is or the edges scale wrong after a resize.
@@ -562,11 +568,17 @@ const ShortestPathLabBackground: React.FC<
         composer.setSize(window.innerWidth, window.innerHeight);
       }
     };
+    const handleResize = () => {
+      if (resizeFrame === null) {
+        resizeFrame = requestAnimationFrame(applyResize);
+      }
+    };
     window.addEventListener('resize', handleResize);
 
     return () => {
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
       window.removeEventListener('resize', handleResize);
+      if (resizeFrame !== null) cancelAnimationFrame(resizeFrame);
       edgeLines.forEach(l => l.geometry.dispose());
       baseEdgeMaterial.dispose();
       exploreEdgeMaterial.dispose();

--- a/src/components/animated-backgrounds/backgrounds/simple-waves/SimpleWaveBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/simple-waves/SimpleWaveBackground.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { SimpleWaveSettings } from './config';
 
@@ -26,7 +27,7 @@ const SimpleWaveBackground: React.FC<
 
     const renderer = new THREE.WebGLRenderer({ alpha: true });
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
 
     container.appendChild(renderer.domElement);
 
@@ -151,14 +152,23 @@ const SimpleWaveBackground: React.FC<
 
     animate(0);
 
-    // Handle window resize
-    const handleResize = () => {
+    // Handle window resize, at most once per frame. A phone's URL bar sliding
+    // in and out fires resize repeatedly over a single flick, and each raw
+    // call reallocates the drawing buffer mid-scroll.
+    let resizeFrame: number | null = null;
+    const applyResize = () => {
+      resizeFrame = null;
       if (renderer && material.uniforms.uResolution) {
         renderer.setSize(window.innerWidth, window.innerHeight);
         material.uniforms.uResolution.value.set(
           window.innerWidth,
           window.innerHeight
         );
+      }
+    };
+    const handleResize = () => {
+      if (resizeFrame === null) {
+        resizeFrame = requestAnimationFrame(applyResize);
       }
     };
 
@@ -171,6 +181,9 @@ const SimpleWaveBackground: React.FC<
       }
 
       window.removeEventListener('resize', handleResize);
+      if (resizeFrame !== null) {
+        cancelAnimationFrame(resizeFrame);
+      }
 
       if (container && renderer.domElement) {
         container.removeChild(renderer.domElement);

--- a/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
+++ b/src/components/animated-backgrounds/backgrounds/spectrogram-oscilloscope/SpectrogramOscilloscopeBackground.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import * as THREE from 'three';
+import { getRenderPixelRatio } from '../../core/renderScale';
 import { AnimatedBackgroundProps } from '../../core/types';
 import { SpectrogramOscilloscopeSettings } from './config';
 
@@ -287,7 +288,7 @@ const SpectrogramOscilloscopeBackground: React.FC<
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
 
     const renderer = new THREE.WebGLRenderer({ alpha: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setPixelRatio(getRenderPixelRatio());
     renderer.setSize(window.innerWidth, window.innerHeight);
 
     container.appendChild(renderer.domElement);
@@ -852,7 +853,9 @@ const SpectrogramOscilloscopeBackground: React.FC<
       mouseRef.current.y = event.clientY * pixelRatio;
     };
 
-    window.addEventListener('mousemove', handleMouseMove);
+    // Passive: the handler only records coordinates for the next frame's
+    // uniform, so the browser never has to wait on it before scrolling.
+    window.addEventListener('mousemove', handleMouseMove, { passive: true });
 
     // Web Audio API functions - now using stable callbacks
 
@@ -917,15 +920,24 @@ const SpectrogramOscilloscopeBackground: React.FC<
 
     animate(0);
 
-    // Handle window resize
-    const handleResize = () => {
+    // Handle window resize, at most once per frame — a phone's URL bar fires
+    // resize repeatedly over a single flick, and each raw call reallocates the
+    // drawing buffer mid-scroll.
+    let resizeFrame: number | null = null;
+    const applyResize = () => {
+      resizeFrame = null;
       if (renderer && material.uniforms.uResolution) {
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        renderer.setPixelRatio(getRenderPixelRatio());
         renderer.setSize(window.innerWidth, window.innerHeight);
         material.uniforms.uResolution.value.set(
           renderer.domElement.width,
           renderer.domElement.height
         );
+      }
+    };
+    const handleResize = () => {
+      if (resizeFrame === null) {
+        resizeFrame = requestAnimationFrame(applyResize);
       }
     };
 
@@ -941,6 +953,9 @@ const SpectrogramOscilloscopeBackground: React.FC<
       stableStopAudio();
 
       window.removeEventListener('resize', handleResize);
+      if (resizeFrame !== null) {
+        cancelAnimationFrame(resizeFrame);
+      }
       window.removeEventListener('mousemove', handleMouseMove);
       window.removeEventListener('keydown', handleKeyDown);
       window.removeEventListener('keyup', handleKeyUp);

--- a/src/components/animated-backgrounds/core/renderScale.ts
+++ b/src/components/animated-backgrounds/core/renderScale.ts
@@ -1,0 +1,26 @@
+import { MOBILE_BREAKPOINT_PX } from './useIsMobileViewport';
+
+// One place for every background's answer to "how many device pixels is a
+// frame worth?". The simulations are soft fields, not text: nobody reads them
+// at 1:1, and the pixels they draw are immediately composited under the
+// window's scrim and blur. On a desktop the old cap of 2 stands. On a phone —
+// where the same fullscreen canvas fights the page's own compositing for a
+// far smaller GPU, and a 3x panel at cap 2 is still ~2M pixels per frame —
+// the cap drops to 1.5, which halves the fill cost and is indistinguishable
+// through the scrim.
+const DESKTOP_MAX_PIXEL_RATIO = 2;
+const MOBILE_MAX_PIXEL_RATIO = 1.5;
+
+export const getRenderPixelRatio = (): number => {
+  if (typeof window === 'undefined') return 1;
+  const dpr = window.devicePixelRatio || 1;
+  const mobile =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX}px)`).matches;
+  return Math.min(
+    dpr,
+    mobile ? MOBILE_MAX_PIXEL_RATIO : DESKTOP_MAX_PIXEL_RATIO
+  );
+};
+
+export default getRenderPixelRatio;

--- a/src/components/animated-backgrounds/core/usePrefersReducedMotion.ts
+++ b/src/components/animated-backgrounds/core/usePrefersReducedMotion.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * True when the OS asks for less motion, tracked live.
+ *
+ * The one-shot `matchMedia(QUERY).matches` reads elsewhere in the shell are
+ * fine where they are: each one runs at the moment it decides whether to
+ * animate a single transition, so it always sees the current preference. This
+ * hook is for the other case — a preference latched into a long-lived effect,
+ * where sampling once means a mid-session toggle (or a battery saver flipping
+ * it for you) never takes effect.
+ *
+ * Starts false so the first client render matches SSR, then settles on mount.
+ */
+export const usePrefersReducedMotion = (): boolean => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const media = window.matchMedia(QUERY);
+    const update = () => setPrefersReducedMotion(media.matches);
+
+    update();
+    media.addEventListener('change', update);
+    return () => media.removeEventListener('change', update);
+  }, []);
+
+  return prefersReducedMotion;
+};
+
+export default usePrefersReducedMotion;

--- a/src/components/chat/MessageSources.tsx
+++ b/src/components/chat/MessageSources.tsx
@@ -48,7 +48,9 @@ const MessageSources: React.FC<MessageSourcesProps> = ({ sources }) => {
       if (e.key === 'Escape') setOpen(false);
     };
     document.addEventListener('mousedown', onPointerDown);
-    document.addEventListener('touchstart', onPointerDown);
+    // Passive: the handler never prevents the default, and a non-passive
+    // document-level touchstart makes every scroll gesture wait on it.
+    document.addEventListener('touchstart', onPointerDown, { passive: true });
     document.addEventListener('keydown', onKeyDown);
     return () => {
       document.removeEventListener('mousedown', onPointerDown);

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -506,6 +506,11 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
       if (o === last) return;
       last = o;
       panel.style.setProperty('--veil-strength', String(o));
+      // At rest the veil is invisible but its backdrop blur was still a live
+      // filter surface the compositor had to keep resolving — over a canvas
+      // that repaints every frame. The class lets the stylesheet take the
+      // whole layer out (visibility) whenever there is nothing to veil.
+      panel.classList.toggle('veil-live', o > 0);
     };
     const onScroll = () => {
       if (frame) return;
@@ -521,6 +526,7 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
       panel.removeEventListener('scroll', onScroll);
       if (frame) window.cancelAnimationFrame(frame);
       syncVeilRef.current = null;
+      panel.classList.remove('veil-live');
     };
   }, []);
 
@@ -529,15 +535,31 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
   // sidebars, whose height must match the window's at all times. A
   // ResizeObserver catches every cause of movement (collapse, hero swap,
   // viewport resize), since each one changes the flex-sized panel's height.
-  React.useEffect(() => {
+  //
+  // Published only while a sidebar exists to read it. The property lives on
+  // the document root — the sidebars render in other subtrees — so each write
+  // invalidates style for the whole document, and the collapse moves this
+  // edge on every scroll frame; running the publisher permanently taxed every
+  // scroll on every page for two panels that are usually closed. A layout
+  // effect, so the value is in place before a freshly opened panel's first
+  // paint.
+  const sidebarVisible =
+    isSettingsPanelOpen ||
+    isClosingSettingsPanel ||
+    isChatPanelOpen ||
+    isClosingChatPanel;
+  React.useLayoutEffect(() => {
     if (typeof window === 'undefined') return;
     const panel = windowRef.current;
-    if (!panel) return;
+    if (!panel || !sidebarVisible) return;
     let frame = 0;
+    let last = '';
     const publish = () => {
       frame = 0;
-      const top = Math.round(panel.getBoundingClientRect().top);
-      document.documentElement.style.setProperty('--window-top', `${top}px`);
+      const top = `${Math.round(panel.getBoundingClientRect().top)}px`;
+      if (top === last) return;
+      last = top;
+      document.documentElement.style.setProperty('--window-top', top);
     };
     const request = () => {
       if (frame) return;
@@ -553,7 +575,7 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
       if (frame) window.cancelAnimationFrame(frame);
       document.documentElement.style.removeProperty('--window-top');
     };
-  }, []);
+  }, [sidebarVisible]);
 
   // The collapse choreography needs real widths: at full collapse the title
   // parks on the left edge and the tagline on the right, each travelling half
@@ -566,6 +588,12 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
     const el = heroRef.current;
     if (!shouldCollapse || !el) return;
 
+    // The observer fires on every frame of the hero's height ease (the region
+    // is the thing being resized), but the widths the split depends on only
+    // change when the text or the column does — so identical readings are
+    // dropped before they turn into style writes, which would otherwise
+    // invalidate the hero's subtree once per animation frame.
+    let lastKey = '';
     const measure = () => {
       const h1 = el.querySelector('h1');
       const sub = el.querySelector('p');
@@ -577,21 +605,22 @@ const LayoutInner: React.FC<LayoutProps> = ({ children, location }) => {
 
       const width = container.clientWidth;
       const subWidth = sub.offsetWidth;
-      el.style.setProperty(
-        '--title-shift',
-        `${(width - h1.offsetWidth) / 2}px`
-      );
-      el.style.setProperty('--sub-shift', `${(width - subWidth) / 2}px`);
-      el.style.setProperty(
-        '--row-lift',
-        `${(h1.offsetHeight + sub.offsetHeight) / 2}px`
-      );
+      const titleShift = (width - h1.offsetWidth) / 2;
+      const subShift = (width - subWidth) / 2;
+      const rowLift = (h1.offsetHeight + sub.offsetHeight) / 2;
       // Whether the tagline actually fits beside the shrunken title. Most of
       // them do, and this is 1; the projects tagline is nearly the full column
       // wide, so it scales down — pinned to its right edge — by exactly the
       // amount it overruns rather than colliding with the title.
       const room = width - h1.offsetWidth * TITLE_SCALE - COLLAPSED_GAP;
       const scale = subWidth > 0 ? Math.min(1, room / subWidth) : 1;
+
+      const key = `${titleShift}|${subShift}|${rowLift}|${scale}`;
+      if (key === lastKey) return;
+      lastKey = key;
+      el.style.setProperty('--title-shift', `${titleShift}px`);
+      el.style.setProperty('--sub-shift', `${subShift}px`);
+      el.style.setProperty('--row-lift', `${rowLift}px`);
       el.style.setProperty('--sub-scale', String(scale));
     };
 

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -106,7 +106,11 @@ const Dropdown: React.FC<DropdownProps> = ({
       close(container.contains(document.activeElement));
     };
     document.addEventListener('mousedown', handlePointerDown);
-    document.addEventListener('touchstart', handlePointerDown);
+    // Passive: the handler never prevents the default, and a non-passive
+    // document-level touchstart makes every scroll gesture wait on it.
+    document.addEventListener('touchstart', handlePointerDown, {
+      passive: true,
+    });
     return () => {
       document.removeEventListener('mousedown', handlePointerDown);
       document.removeEventListener('touchstart', handlePointerDown);

--- a/src/styles/404.scss
+++ b/src/styles/404.scss
@@ -35,7 +35,7 @@
   color: var(--text-primary);
   text-decoration: none;
   border-radius: var(--radius-lg);
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
   box-shadow: var(--shadow-md);
 
   &:hover {

--- a/src/styles/animated-backgrounds.scss
+++ b/src/styles/animated-backgrounds.scss
@@ -27,7 +27,7 @@
   flex-direction: column;
   gap: 1rem;
   font-family: 'JetBrains Mono', 'Fira Code', monospace;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  @include control-transition(0.3s cubic-bezier(0.16, 1, 0.3, 1));
 
   // Slide in from left with fade when appearing
   animation: slideInFromLeftWithFade 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
@@ -53,7 +53,7 @@
     @include capsule-housing;
     color: var(--text-secondary);
     font-size: 0.875rem;
-    transition: all var(--transition-normal);
+    @include control-transition(var(--transition-normal));
     cursor: pointer; // Indicate clickable
 
     &:hover {
@@ -163,7 +163,7 @@
           display: flex;
           align-items: center;
           justify-content: center;
-          transition: all var(--transition-fast);
+          @include control-transition(var(--transition-fast));
           font-family: inherit;
 
           &:hover {
@@ -208,7 +208,7 @@
         border-radius: var(--radius-sm);
         border: 1px solid var(--border-color);
         background: var(--bg-primary);
-        transition: all var(--transition-fast);
+        @include control-transition(var(--transition-fast));
 
         &:hover {
           background: var(--bg-hover);
@@ -274,7 +274,7 @@
             font-size: 0.75rem;
             font-family: inherit;
             cursor: pointer;
-            transition: all 0.15s ease;
+            @include control-transition(0.15s ease);
             display: flex;
             align-items: center;
             gap: 0.5rem;
@@ -346,7 +346,7 @@
       display: flex;
       align-items: center;
       font-size: 0.8125rem; // slightly smaller
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
       font-family: inherit;
 
       &:hover {
@@ -441,7 +441,7 @@
       line-height: 1;
       cursor: help;
       vertical-align: middle;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
 
       &:hover,
       &:focus-visible {
@@ -513,7 +513,7 @@
           background: var(--text-primary);
           border-radius: 50%;
           cursor: pointer;
-          transition: all var(--transition-fast);
+          @include control-transition(var(--transition-fast));
           box-shadow: 0 0 0 2px var(--bg-secondary);
 
           &:hover {
@@ -528,7 +528,7 @@
           border-radius: 50%;
           border: 2px solid var(--bg-secondary);
           cursor: pointer;
-          transition: all var(--transition-fast);
+          @include control-transition(var(--transition-fast));
 
           &:hover {
             transform: scale(1.2);
@@ -662,7 +662,7 @@
       color: var(--text-primary);
       font-size: 0.8125rem; // Match chat font sizing
       cursor: pointer;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
       font-family: inherit;
       margin-bottom: 1rem;
 
@@ -870,9 +870,15 @@
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
     border: none;
     border-top: 1px solid rgba(255, 255, 255, 0.18);
-    background: rgba(8, 10, 14, 0.55);
-    backdrop-filter: blur(16px) saturate(140%);
-    -webkit-backdrop-filter: blur(16px) saturate(140%);
+    // Tint only, no backdrop filter. The blur+saturate here asked the phone's
+    // GPU to re-filter a full-width band of a canvas that repaints every
+    // frame, for as long as the sheet was up — which is exactly when the user
+    // is watching that canvas react to the sliders. The unobstructed upper
+    // half of the screen is where the background is actually watched; the
+    // sheet itself only owes its own labels a readable surface, and a slightly
+    // deeper tint does that alone. The slide up and down is now a pure
+    // compositor move.
+    background: rgba(8, 10, 14, 0.72);
     box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
     padding-bottom: env(safe-area-inset-bottom);
 
@@ -1058,7 +1064,7 @@
       font-size: 0.75rem;
       font-style: italic;
       cursor: pointer;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
 
       &.open {
         color: var(--text-primary);
@@ -1097,7 +1103,7 @@
       text-transform: lowercase;
       white-space: nowrap;
       cursor: pointer;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
       -webkit-tap-highlight-color: transparent;
 
       // Categories a background defines for itself lead; the shared ones read

--- a/src/styles/animated-backgrounds.scss
+++ b/src/styles/animated-backgrounds.scss
@@ -870,15 +870,19 @@
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
     border: none;
     border-top: 1px solid rgba(255, 255, 255, 0.18);
-    // Tint only, no backdrop filter. The blur+saturate here asked the phone's
-    // GPU to re-filter a full-width band of a canvas that repaints every
-    // frame, for as long as the sheet was up — which is exactly when the user
-    // is watching that canvas react to the sliders. The unobstructed upper
-    // half of the screen is where the background is actually watched; the
-    // sheet itself only owes its own labels a readable surface, and a slightly
-    // deeper tint does that alone. The slide up and down is now a pure
-    // compositor move.
-    background: rgba(8, 10, 14, 0.72);
+    // No background or backdrop-filter override: the sheet keeps the base
+    // rule's frosted glass — the same --window-scrim over blur(--window-blur)
+    // the content window and the desktop sidebar wear — so the whole kit is
+    // one material. (A 16px blur+saturate over its own tint used to live
+    // here; it was both the odd surface out and the most expensive thing a
+    // phone GPU was asked to hold.)
+    //
+    // The glass is worn only at rest: sliding a full-width backdrop filter
+    // over a canvas that repaints every frame forces the blur to be
+    // re-resolved per frame of the slide, which is exactly the 300ms the
+    // phone is also compositing the move itself. So the sheet travels as
+    // tint alone and the blur fades in once it has parked — the second
+    // animation below, keyframes further down.
     box-shadow: 0 -12px 40px rgba(0, 0, 0, 0.45);
     padding-bottom: env(safe-area-inset-bottom);
 
@@ -886,11 +890,18 @@
     z-index: 1003;
 
     // A sheet comes up from and goes back down to the bottom edge; the
-    // sidebar's horizontal slide reads wrong here.
-    animation: slideUpSheet 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    // sidebar's horizontal slide reads wrong here. The second animation is
+    // the blur arriving after the slide: `backwards` holds its filter-less
+    // first frame through the delay, so the static blur above never applies
+    // while the sheet is in motion.
+    animation:
+      slideUpSheet 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+      sheet-blur-in 220ms ease 0.3s backwards;
 
     &.closing {
       animation: slideDownToSheet 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
 
     // Grab-handle affordance along the top edge.
@@ -1137,6 +1148,20 @@
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+// The sheet's frosted glass arriving after the slide (see .settings-sidebar's
+// mobile block): `none` interpolates from blur(0), so this is a short fade-up
+// to the window's own resting blur rather than a pop.
+@keyframes sheet-blur-in {
+  from {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  to {
+    backdrop-filter: blur(var(--window-blur));
+    -webkit-backdrop-filter: blur(var(--window-blur));
   }
 }
 

--- a/src/styles/blog.scss
+++ b/src/styles/blog.scss
@@ -210,7 +210,7 @@
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
   text-transform: lowercase;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   .post-meta & {
     margin-left: auto;
@@ -342,7 +342,7 @@
   a {
     color: var(--ink-primary);
     text-decoration: none;
-    transition: all var(--transition-fast);
+    @include control-transition(var(--transition-fast));
 
     &:hover {
       text-decoration: underline;
@@ -418,7 +418,7 @@
   color: white;
   @include over-background;
   text-decoration: none;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   &:hover {
     color: var(--primary-color);

--- a/src/styles/chat.scss
+++ b/src/styles/chat.scss
@@ -481,28 +481,45 @@
     width: 100vw;
     height: 100vh;
     height: 100dvh; // Dynamic viewport height for mobile browsers
-    // Tint only, no backdrop filter. At 0.92 the blur was contributing almost
-    // nothing to legibility — the last 8% of a live simulation reads as a
-    // faint shimmer either way — but a full-screen blur+saturate over a canvas
-    // that repaints every frame is the single most expensive surface a phone
-    // GPU can be asked to hold, and it ran for the whole life of the sheet,
-    // including both 300ms slides. A couple of points more tint buys the same
-    // reading surface at a fraction of the price, and the slide becomes a pure
-    // compositor move.
-    background: rgba(7, 8, 10, 0.96);
+    // No background or backdrop-filter override: the sheet wears the same
+    // frosted glass as the content window and the desktop sidebar — the base
+    // rule's --window-scrim over blur(--window-blur) — so the whole kit is
+    // one material. (A near-opaque tint with a 16px blur+saturate used to
+    // live here; it was both the odd surface out and the most expensive
+    // thing a phone GPU was asked to hold.)
+    //
+    // The glass is worn only at rest. Sliding a full-screen backdrop filter
+    // over a canvas that repaints every frame forces the blur to be
+    // re-resolved on every frame of the slide, so the sheet travels as tint
+    // alone (the states below) and the blur fades back in once it has
+    // parked, via this transition.
+    transition:
+      backdrop-filter 220ms ease,
+      -webkit-backdrop-filter 220ms ease;
     border: none;
     border-radius: 0;
     box-shadow: none;
     z-index: 1003;
 
     // A sheet that owns the screen comes up from the bottom edge; the
-    // sidebar's horizontal slide reads wrong at this size.
+    // sidebar's horizontal slide reads wrong at this size. Both states shed
+    // the backdrop filter for the length of the move (see the note on the
+    // sheet's own blur above): the class drops ~300ms after opening, which is
+    // what hands the blur back through the transition.
     &.opening {
       animation: slideInFromBottom 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
 
     &.closing {
       animation: slideOutToBottom 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      // An instant cut, not the settle fade in reverse: easing the blur out
+      // would keep a shrinking filter live under most of the slide, and a
+      // departing sheet has no rest state for the glass to belong to.
+      transition: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
     }
 
     // Edge to edge means edge to edge: the sheet runs under the status bar and

--- a/src/styles/chat.scss
+++ b/src/styles/chat.scss
@@ -47,7 +47,7 @@
     color: var(--text-secondary);
     font-size: 0.875rem;
     cursor: pointer;
-    transition: all var(--transition-normal);
+    @include control-transition(var(--transition-normal));
 
     &:hover {
       border-color: rgba(255, 255, 255, 0.45);
@@ -206,7 +206,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        transition: all var(--transition-normal);
+        @include control-transition(var(--transition-normal));
         position: relative;
 
         &:hover {
@@ -277,7 +277,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: all var(--transition-normal);
+      @include control-transition(var(--transition-normal));
 
       &:hover:not(:disabled) {
         border-color: var(--border-active);
@@ -351,7 +351,7 @@
         resize: none;
         min-height: 44px;
         max-height: 120px;
-        transition: all var(--transition-normal);
+        @include control-transition(var(--transition-normal));
 
         &:focus {
           outline: none;
@@ -380,7 +380,7 @@
         cursor: pointer;
         font-size: 0.875rem;
         font-family: 'JetBrains Mono', 'Fira Code', monospace;
-        transition: all var(--transition-normal);
+        @include control-transition(var(--transition-normal));
         min-width: 60px;
         height: 44px;
         display: flex;
@@ -481,9 +481,15 @@
     width: 100vw;
     height: 100vh;
     height: 100dvh; // Dynamic viewport height for mobile browsers
-    background: rgba(7, 8, 10, 0.92);
-    backdrop-filter: blur(16px) saturate(140%);
-    -webkit-backdrop-filter: blur(16px) saturate(140%);
+    // Tint only, no backdrop filter. At 0.92 the blur was contributing almost
+    // nothing to legibility — the last 8% of a live simulation reads as a
+    // faint shimmer either way — but a full-screen blur+saturate over a canvas
+    // that repaints every frame is the single most expensive surface a phone
+    // GPU can be asked to hold, and it ran for the whole life of the sheet,
+    // including both 300ms slides. A couple of points more tint buys the same
+    // reading surface at a fraction of the price, and the slide becomes a pure
+    // compositor move.
+    background: rgba(7, 8, 10, 0.96);
     border: none;
     border-radius: 0;
     box-shadow: none;
@@ -540,7 +546,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  @include control-transition(0.3s cubic-bezier(0.4, 0, 0.2, 1));
 
   &.opening {
     animation: slideInUp 0.3s ease-out;
@@ -638,7 +644,7 @@
       align-items: center;
       justify-content: center;
       border-radius: 8px;
-      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
 
       &:hover {
         background: var(--bg-hover);
@@ -725,7 +731,7 @@
         padding: 0.75rem 1rem;
         cursor: pointer;
         font-size: 0.875rem;
-        transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+        @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
 
         &:hover:not(:disabled) {
           background: var(--bg-accent);
@@ -879,7 +885,7 @@
         font-size: 0.6875rem;
         letter-spacing: 0.03em;
         cursor: pointer;
-        transition: all var(--transition-normal);
+        @include control-transition(var(--transition-normal));
 
         &:hover,
         &:focus-visible,
@@ -931,7 +937,7 @@
         font-size: 0.75rem;
         line-height: 1.35;
         text-decoration: none;
-        transition: all var(--transition-normal);
+        @include control-transition(var(--transition-normal));
 
         &:hover,
         &:focus-visible {
@@ -1185,7 +1191,7 @@
   border-radius: 2px;
   flex-shrink: 0;
   margin-left: 0.5rem;
-  transition: all 0.2s ease;
+  @include control-transition(0.2s ease);
 
   &:hover {
     color: var(--text-primary);
@@ -1488,7 +1494,7 @@
       border-radius: 8px;
       font-size: 0.875rem;
       cursor: pointer;
-      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
       min-width: 100px;
       backdrop-filter: blur(10px);
       -webkit-backdrop-filter: blur(10px); // Safari 17 and earlier
@@ -1575,7 +1581,7 @@
   background: rgba(255, 255, 255, 0.04);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   &:hover {
     border-color: var(--border-active);
@@ -1658,7 +1664,7 @@
     .thinking-chevron {
       color: #8b5cf6;
       opacity: 0.7;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
       display: flex;
       align-items: center;
 
@@ -1771,7 +1777,7 @@
     border: 1px solid var(--border-color);
     border-radius: 12px;
     cursor: pointer;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
     text-align: left;
     font-size: 0.8rem;
     color: var(--text-secondary);
@@ -1904,7 +1910,7 @@
           background: transparent;
           border-radius: 8px;
           border: 1px solid rgba(255, 255, 255, 0.08);
-          transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+          @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
 
           &:hover {
             background: var(--bg-hover);
@@ -1958,7 +1964,7 @@
           padding: 0.5rem 0.75rem;
           cursor: pointer;
           font-family: inherit;
-          transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+          @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
 
           &:hover {
             background: var(--bg-hover);
@@ -2012,7 +2018,7 @@
         padding: 0.75rem 1.25rem;
         font-size: 0.8125rem; // Match reset button font sizing
         cursor: pointer;
-        transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+        @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
         flex: 1;
         font-family: inherit;
 
@@ -2045,7 +2051,7 @@
         border-radius: 8px;
         padding: 0.75rem;
         cursor: pointer;
-        transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+        @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
         flex-shrink: 0;
 
         &:hover {
@@ -2139,7 +2145,7 @@
             border-radius: var(--radius-sm);
             border: 1px solid var(--border-color);
             background: var(--bg-primary);
-            transition: all var(--transition-fast);
+            @include control-transition(var(--transition-fast));
 
             &:hover {
               background: var(--bg-hover);
@@ -2401,7 +2407,7 @@
       align-items: center;
       justify-content: center;
       border-radius: var(--radius-sm);
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
       opacity: 0;
       transform: translateY(2px);
 
@@ -2523,7 +2529,7 @@
       border-radius: 8px;
       padding: 0.5rem 0.875rem;
       cursor: pointer;
-      transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      @include control-transition(0.2s cubic-bezier(0.4, 0, 0.2, 1));
 
       &:disabled {
         opacity: 0.5;

--- a/src/styles/controls.scss
+++ b/src/styles/controls.scss
@@ -122,7 +122,7 @@
   white-space: nowrap;
   cursor: pointer;
   user-select: none;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   // One highlight for both routes in: the pointer and the arrow keys set the
   // same active index, so hover and keyboard cannot disagree about which item
@@ -230,7 +230,7 @@
     // sections and runs past a phone's field, and a clean elision reads as a
     // sentence continuing rather than as a word cut in half.
     text-overflow: ellipsis;
-    transition: all var(--transition-fast);
+    @include control-transition(var(--transition-fast));
 
     // Focus is a state of a text field rather than a result, so it says so
     // with a brighter hairline — matching the chips in the row above rather

--- a/src/styles/cv.scss
+++ b/src/styles/cv.scss
@@ -333,7 +333,7 @@ section[id] {
     color: var(--text-secondary);
     font-size: 0.7rem;
     line-height: 1;
-    transition: all var(--transition-normal);
+    @include control-transition(var(--transition-normal));
   }
 }
 
@@ -747,7 +747,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
   font-size: 0.925rem;
   @include outline-block;
   color: var(--text-secondary);
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
   cursor: default;
 
   // A label the pointer cannot do anything with does not jump when the
@@ -786,7 +786,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
       padding: 1rem;
       border-bottom: 1px solid rgba(255, 255, 255, 0.08);
       cursor: pointer;
-      transition: all var(--transition-fast);
+      @include control-transition(var(--transition-fast));
 
       &:last-child {
         border-bottom: none;
@@ -938,7 +938,7 @@ details[open] .cv-collapse-summary .cv-collapse-chevron {
     padding: 0.5rem 1rem;
     border-radius: var(--radius-md);
     cursor: pointer;
-    transition: all var(--transition-normal);
+    @include control-transition(var(--transition-normal));
 
     &:hover {
       background: rgba(255, 255, 255, 0.06);

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -46,7 +46,6 @@ body {
     );
   background-attachment: fixed;
   min-height: 100vh;
-  transition: background var(--transition-slow);
   position: relative;
 
   // Reduce opacity of grid texture to let Three.js background shine through
@@ -196,5 +195,36 @@ img {
 @media (max-width: 768px) {
   .container {
     padding: 0 0.5rem;
+  }
+}
+
+/* Reduced motion, stated once for the chrome that moves. The hero transition
+   already checks the preference in the shell (layout.tsx), and the collapse
+   easing opts out in layout.scss; this covers the rest — the panel slides, the
+   stage shift, and the decorative infinite loops. Panels still open and close;
+   they simply appear in place. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  .stage,
+  .nav,
+  .background-controls {
+    transition: none;
+  }
+
+  .chat-sidebar,
+  .settings-sidebar,
+  .chat-icon-container,
+  .background-controls {
+    animation: none !important;
+  }
+
+  .animate-glow,
+  .animate-bounce,
+  .animate-pulse,
+  .animate-rotate {
+    animation: none;
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -26,7 +26,13 @@
   // the field is interactive — the simulations respond to the pointer. Only
   // the three real children take clicks; the gaps between them pass through.
   pointer-events: none;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  // Only what the panel choreography actually moves: the side offsets on a
+  // desktop, the dim on a phone. `all` here also armed top/bottom and every
+  // inherited property, and made each state flip a full style diff.
+  transition:
+    left 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    right 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
   > * {
     pointer-events: auto;
@@ -55,12 +61,10 @@
   // snap back once the closing class dropped.
   &.settings-panel-closing {
     left: var(--window-side);
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   &.chat-panel-closing {
     right: var(--window-side);
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
   }
 
   // Handle mixed states - one opening, one closing
@@ -245,6 +249,16 @@
       --collapsed-title-scale: 0.44;
     }
 
+    // No easing between scroll samples on a phone. Touch scroll delivers a
+    // continuous stream of positions, so there are no wheel-notch jumps for a
+    // 120ms tail to smooth over — what the tail actually did here was keep
+    // padding, margin and max-height animating (and the flex window
+    // relayouting, and its backdrop blur re-resolving) for 120ms after every
+    // single scroll frame. Tracking the finger exactly is both the cheaper
+    // frame and the more responsive one. The desktop rules below keep their
+    // easing; a mouse wheel steps.
+    transition: none;
+
     h1 {
       // Right-to-left: scale first (about the left edge, so --title-shift
       // stays honest at any scale), then the unscaled rise and slide. The
@@ -272,15 +286,13 @@
         var(--space-3) * (1 - var(--hero-collapse)) - 1.15em *
           var(--hero-collapse)
       );
-      transition:
-        transform 120ms linear,
-        margin-bottom 120ms linear;
+      transition: none;
     }
 
     // The tail goes with the tagline; the anchor keeps its ink the whole way.
     .hero-crumb-rest {
       opacity: calc(1 - var(--hero-collapse));
-      transition: opacity 120ms linear;
+      transition: none;
     }
 
     p {
@@ -288,10 +300,7 @@
       max-height: calc(6rem * (1 - var(--hero-collapse)));
       overflow: hidden;
       transform: translateY(calc(-0.5rem * var(--hero-collapse)));
-      transition:
-        opacity 120ms linear,
-        max-height 120ms linear,
-        transform 120ms linear;
+      transition: none;
     }
   }
 
@@ -330,6 +339,11 @@
     // fades in over the first ~90px of scroll (Layout publishes the value).
     opacity: var(--veil-strength, 0);
     transition: opacity 80ms linear;
+    // Fully invisible is fully off. An opacity-0 backdrop filter is still a
+    // live filter surface — over a canvas that repaints every frame, the
+    // compositor kept resolving an 18px blur nobody could see. The shell
+    // marks the window `veil-live` the moment there is any scroll to veil.
+    visibility: hidden;
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px); // Safari 17 and earlier
     // Near-opaque at the very edge — content genuinely disappears under the
@@ -388,6 +402,12 @@
       );
     }
   }
+}
+
+// Anything scrolled under the veil: the blur layer comes back for exactly as
+// long as --veil-strength is above zero.
+.veil-live .window-veil::before {
+  visibility: visible;
 }
 
 // The content window — the scrolling panel the page lives in. It no longer
@@ -465,7 +485,11 @@
   justify-content: flex-end;
   align-items: center;
   flex-wrap: nowrap;
-  transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+  // Right for the phone offset change, opacity for the phone dim — the two
+  // things the capsule's panel states actually touch.
+  transition:
+    right 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
   // The capsule does not dodge. It used to slide inward by the sidebar's width
   // whenever the chat opened, which put the one fixed landmark on the field in
@@ -596,7 +620,7 @@
   color: var(--text-secondary);
   text-decoration: none;
   border-radius: var(--radius-md);
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
   position: relative;
   overflow: hidden;
 
@@ -613,7 +637,7 @@
     display: inline-flex;
     width: 1.25rem;
     height: 1.25rem;
-    transition: all var(--transition-normal);
+    @include control-transition(var(--transition-normal));
 
     svg {
       width: 100%;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,5 +1,23 @@
 // SCSS Mixins for consistent styling patterns
 
+// The properties a control is allowed to ease, spelled out. `transition: all`
+// used to be the house habit, and it quietly promised to animate anything that
+// ever changed — including layout properties like width and padding, which
+// cannot be animated off the main thread. Every state change on this site is
+// some mix of ink, surface, hairline, elevation and a small transform, so that
+// is the whole list; a control that needs to ease anything else declares it
+// itself.
+@mixin control-transition($duration: var(--transition-fast)) {
+  transition:
+    color $duration,
+    background-color $duration,
+    border-color $duration,
+    box-shadow $duration,
+    opacity $duration,
+    filter $duration,
+    transform $duration;
+}
+
 @mixin button-base {
   display: inline-flex;
   align-items: center;
@@ -8,7 +26,7 @@
   border-radius: var(--radius-sm);
   text-decoration: none;
   font-size: 0.875rem;
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
   border: 2px solid transparent;
   cursor: pointer;
   position: relative;
@@ -152,7 +170,7 @@
 // change hue: the card is not a link and not a state, so there is nothing for
 // a colour to say here.
 @mixin card-hover {
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
 
   &:hover {
     transform: translateY(-2px);
@@ -241,6 +259,16 @@
   background: transparent;
   backdrop-filter: blur(calc(var(--window-blur) * 4));
   -webkit-backdrop-filter: blur(calc(var(--window-blur) * 4)); // Safari ≤17
+
+  // Half the radius on a phone. The chips sit over content that is moving —
+  // the one case a backdrop filter has to re-resolve every frame — and they
+  // share those frames with the veil above them and the window's own blur. A
+  // 10px smear still destroys a heading sliding under the chip; what it stops
+  // doing is asking a phone GPU for the desktop radius on every scroll frame.
+  @media (max-width: 768px) {
+    backdrop-filter: blur(calc(var(--window-blur) * 2));
+    -webkit-backdrop-filter: blur(calc(var(--window-blur) * 2));
+  }
   border: 1px solid var(--border-floating);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
@@ -253,7 +281,7 @@
   letter-spacing: -0.01em;
   white-space: nowrap;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   // Without a backdrop filter there is nothing at all between the label and
   // whatever passes under it, so the old scrim comes back on those engines

--- a/src/styles/mobile-interactivity.scss
+++ b/src/styles/mobile-interactivity.scss
@@ -55,7 +55,7 @@ $mobile-breakpoint: 768px;
   @include capsule-housing;
   color: var(--text-secondary); // The chat launcher's ink, for the same reason
   cursor: pointer;
-  transition: all var(--transition-normal);
+  @include control-transition(var(--transition-normal));
   -webkit-tap-highlight-color: transparent;
 
   // The glyph is the whole label, so it takes the text colour rather than the
@@ -226,7 +226,7 @@ $mobile-breakpoint: 768px;
   font-size: 1.4rem;
   line-height: 1;
   cursor: pointer;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
   -webkit-tap-highlight-color: transparent;
 
   &:active {

--- a/src/styles/projects.scss
+++ b/src/styles/projects.scss
@@ -202,7 +202,7 @@
     'JetBrains Mono', 'Fira Code', 'Monaco', 'Consolas', 'Courier New',
     monospace;
   text-transform: lowercase;
-  transition: all var(--transition-fast);
+  @include control-transition(var(--transition-fast));
 
   .project-card:hover & {
     border-color: rgba(255, 255, 255, 0.32);


### PR DESCRIPTION
## Why

Transitions were laggy, especially on mobile. Profiling the code paths turned up three compounding loads, and every janky moment on the site was some stack of them:

1. **Layout-property animation.** `transition: all` on 53 selectors (including the fixed-position `.stage` and `.nav`), 120ms transitions on `padding`/`margin`/`max-height` chasing the scroll-linked hero collapse, so the flex window — and its backdrop blur — kept relayouting for 120ms after *every scroll frame*.
2. **Backdrop filters over a live canvas.** The WebGL backgrounds repaint every frame, so every backdrop filter above them re-resolves every frame — including the mobile sheets' bespoke 16px blur+saturate coats (held live through both 300ms slides) and the window veil's 18px blur kept alive at opacity 0.
3. **Over-wide invalidation.** `--window-top` written on `document.documentElement` on every scroll frame (document-wide style invalidation) for two sidebars that are usually closed; context providers handing out fresh identities on every render; the settings persist stringifying the whole blob per slider input event.

## What changed

**Stylesheet**
- New `control-transition` mixin (ink / surface / hairline / shadow / opacity / filter / transform) replaces every `transition: all`. Nothing layout-bearing is animatable anymore; every hover and state change looks identical.
- `.stage` and `.nav` transition exactly what their panel states move: `left`/`right`/`opacity`.
- The mobile hero collapse tracks the finger 1:1 (no 120ms easing tail). Touch scroll is continuous, so the easing was pure cost; desktop keeps it because a mouse wheel steps.
- **One frosted glass for the whole kit.** The mobile chat and settings sheets drop their own heavier 16px blur+saturate coats and wear the same material as the content window and desktop sidebars: `--window-scrim` over `blur(--window-blur)`. And the glass is worn *only at rest* — the sheets shed the backdrop filter for the length of their 300ms slides (pure compositor moves) and fade it back in once parked.
- The window veil's 18px blur is visibility-gated: the filter surface exists only while there is scroll to veil.
- Sticky control chips halve their blur radius on phones (20px → 10px) — they sit over moving content, the one case a backdrop filter re-resolves per frame.
- `prefers-reduced-motion` now also covers panel slides, the stage shift, smooth scrolling, the decorative infinite loops, and the 12s background cycle's fullscreen fade.

**Shell (`layout.tsx`)**
- `--window-top` publishes only while a sidebar exists to read it (layout-effect gated on panel visibility, writes deduped).
- The hero measure observer drops identical readings instead of rewriting four custom properties on every frame of the hero height ease.

**WebGL backgrounds**
- Shared `getRenderPixelRatio()`: cap 1.5 on phone-width viewports (desktop keeps 2). Roughly half the fill cost per frame, invisible through the window's scrim.
- All six backgrounds collapse resize bursts to one application per frame — a phone's URL bar fires `resize` repeatedly over a single flick, and each raw call reallocated the drawing buffer mid-scroll.
- The spectrogram's `mousemove` listener is passive.

**React**
- `SettingsPanelContext` and `BackgroundProvider` memoize their context values and setters; the settings persist to localStorage is debounced.
- Document-level `touchstart` listeners (dropdown, sources popover) are passive so scroll gestures never wait on them.
- Mobile state fix: the settings sheet's open flag persists in localStorage but explore mode does not, so a sheet left open on a desktop restored on a phone with the page content still mounted behind it — dimmed by the stage's generic panel fallback instead of hidden. On mobile an open settings sheet now adopts explore mode, so the background it exists to tune is full-bleed behind it.
- Bug found along the way: the panel-state restore treated a stubbed storage's `undefined` as "saved: closed". Fixed with a `!= null` guard (previously masked by the unstable setter identity re-running the caller's effect).

## Performance tests

New `e2e/performance.spec.ts` so the pass is measurable and guarded against regression:

- **Structural guards** (all browser projects): the stage/nav transition an explicit property list rather than `all`; `--window-top` publishes only while a sidebar is up; the veil keeps no live blur surface at rest; the sheets' moving states carry `backdrop-filter: none` in the stylesheet; the background canvas honours the 1.5 mobile pixel-ratio cap.
- **Measured metrics** (chromium): scroll frame times on the longest page and long-task totals across a navigation, attached to the test report (`scroll-frame-times`, `navigation-long-tasks`) for comparison across runs, with sanity ceilings sized for software-GL CI hardware that still trip on catastrophic regressions.

## Verification

- `npm run type-check` ✅ `npm run lint` ✅ prettier ✅
- Full jest suite: 579 passed, 0 failed
- `npm run build` ✅
- Performance spec: 10 passed on chromium + Mobile Chrome against the production build (4 cross-project skips by design); resting sheet material verified as computed `blur(5px)` over `rgba(7,8,10,0.38)` — identical to the window's.

## Not touched (possible follow-ups)

- The navigation's 260ms hero `height` ease is the design's signature move and stays; everything that made it drop frames around it (measure rewrites, `--window-top`, veil) is now off its critical path.
- `content-visibility: auto` on the long list pages could further cut layout cost during navigation, but wants on-device verification of scroll anchoring first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hxw7dBa8g4V8RAd49nXjwz